### PR TITLE
Add Atom and JSON feeds + feed links in individual articles

### DIFF
--- a/app/lish/[did]/[publication]/[rkey]/page.tsx
+++ b/app/lish/[did]/[publication]/[rkey]/page.tsx
@@ -65,6 +65,8 @@ export async function generateMetadata(props: {
       ? {
           types: {
             "application/rss+xml": `https://${pubRecord?.base_path}/rss`,
+            "application/atom+xml": `https://${pubRecord?.base_path}/atom`,
+            "application/json": `https://${pubRecord?.base_path}/json`,
           },
         }
       : undefined,

--- a/app/lish/[did]/[publication]/[rkey]/page.tsx
+++ b/app/lish/[did]/[publication]/[rkey]/page.tsx
@@ -20,7 +20,6 @@ import { PostPageContextProvider } from "./PostPageContext";
 import { PostPage } from "./PostPage";
 import { PageLayout } from "./PageLayout";
 import { extractCodeBlocks } from "./extractCodeBlocks";
-import { generatePublicationMetadata } from "../layout";
 
 export async function generateMetadata(props: {
   params: Promise<{ publication: string; did: string; rkey: string }>;
@@ -40,13 +39,10 @@ export async function generateMetadata(props: {
   if (!document) return { title: "404" };
 
   let docRecord = document.data as PubLeafletDocument.Record;
-  const pubMetadata = await generatePublicationMetadata(did, publication);
-  const feedAlternates = pubMetadata?.alternates;
 
   return {
     title: docRecord.title + " - " + publication,
     description: docRecord?.description || "",
-    alternates: feedAlternates,
   };
 }
 export default async function Post(props: {

--- a/app/lish/[did]/[publication]/atom/route.ts
+++ b/app/lish/[did]/[publication]/atom/route.ts
@@ -1,16 +1,5 @@
-import { AtUri } from "@atproto/syntax";
-import { get_publication_data } from "app/api/rpc/[command]/get_publication_data";
-import { Feed } from "feed";
-import fs from "fs/promises";
-import {
-  PubLeafletDocument,
-  PubLeafletPagesLinearDocument,
-  PubLeafletPublication,
-} from "lexicons/api";
-import { NextRequest, NextResponse } from "next/server";
-import { createElement } from "react";
-import { supabaseServerClient } from "supabase/serverClient";
-import { StaticPostContent } from "../[rkey]/StaticPostContent";
+import { NextResponse } from "next/server";
+import { generateFeed } from "../layout";
 
 export async function GET(
   req: Request,
@@ -21,69 +10,15 @@ export async function GET(
   let renderToReadableStream = await import("react-dom/server").then(
     (module) => module.renderToReadableStream,
   );
-  let params = await props.params;
-  let { result: publication } = await get_publication_data.handler(
-    {
-      did: params.did,
-      publication_name: decodeURIComponent(params.publication),
-    },
-    { supabase: supabaseServerClient },
-  );
+  const params = await props.params;
+  const did = decodeURIComponent(params.did);
+  const publication = decodeURIComponent(params.publication);
+  const feed = await generateFeed(did, publication);
 
-  let pubRecord = publication?.record as PubLeafletPublication.Record;
-  if (!publication || !pubRecord)
-    return new NextResponse(null, { status: 404 });
+  if (feed instanceof NextResponse) {
+    return feed;
+  }
 
-  const feed = new Feed({
-    title: pubRecord.name,
-    description: pubRecord.description,
-    id: `https://${pubRecord.base_path}`,
-    link: `https://${pubRecord.base_path}`,
-    language: "en", // optional, used only in RSS 2.0, possible values: http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
-    copyright: "",
-    feedLinks: {
-      rss: `https://${pubRecord.base_path}/rss`,
-      atom: `https://${pubRecord.base_path}/atom`,
-      json: `https://${pubRecord.base_path}/json`,
-    },
-  });
-
-  await Promise.all(
-    publication?.documents_in_publications.map(async (doc) => {
-      if (!doc.documents) return;
-      let record = doc.documents?.data as PubLeafletDocument.Record;
-      let uri = new AtUri(doc.documents?.uri);
-      let rkey = uri.rkey;
-      if (!record) return;
-      let firstPage = record.pages[0];
-      let blocks: PubLeafletPagesLinearDocument.Block[] = [];
-      if (PubLeafletPagesLinearDocument.isMain(firstPage)) {
-        blocks = firstPage.blocks || [];
-      }
-      let stream = await renderToReadableStream(
-        createElement(StaticPostContent, { blocks, did: uri.host }),
-      );
-      const reader = stream.getReader();
-      const chunks = [];
-
-      let done, value;
-      while (!done) {
-        ({ done, value } = await reader.read());
-        if (value) {
-          chunks.push(new TextDecoder().decode(value));
-        }
-      }
-
-      feed.addItem({
-        title: record.title,
-        description: record.description,
-        date: record.publishedAt ? new Date(record.publishedAt) : new Date(),
-        id: `https://${pubRecord.base_path}/${rkey}`,
-        link: `https://${pubRecord.base_path}/${rkey}`,
-        content: chunks.join(""),
-      });
-    }),
-  );
   return new Response(feed.atom1(), {
     headers: {
       "Content-Type": "application/atom+xml",

--- a/app/lish/[did]/[publication]/atom/route.ts
+++ b/app/lish/[did]/[publication]/atom/route.ts
@@ -84,9 +84,9 @@ export async function GET(
       });
     }),
   );
-  return new Response(feed.rss2(), {
+  return new Response(feed.atom1(), {
     headers: {
-      "Content-Type": "application/rss+xml",
+      "Content-Type": "application/atom+xml",
     },
   });
 }

--- a/app/lish/[did]/[publication]/json/route.ts
+++ b/app/lish/[did]/[publication]/json/route.ts
@@ -1,16 +1,5 @@
-import { AtUri } from "@atproto/syntax";
-import { get_publication_data } from "app/api/rpc/[command]/get_publication_data";
-import { Feed } from "feed";
-import fs from "fs/promises";
-import {
-  PubLeafletDocument,
-  PubLeafletPagesLinearDocument,
-  PubLeafletPublication,
-} from "lexicons/api";
-import { NextRequest, NextResponse } from "next/server";
-import { createElement } from "react";
-import { supabaseServerClient } from "supabase/serverClient";
-import { StaticPostContent } from "../[rkey]/StaticPostContent";
+import { NextResponse } from "next/server";
+import { generateFeed } from "../layout";
 
 export async function GET(
   req: Request,
@@ -21,69 +10,15 @@ export async function GET(
   let renderToReadableStream = await import("react-dom/server").then(
     (module) => module.renderToReadableStream,
   );
-  let params = await props.params;
-  let { result: publication } = await get_publication_data.handler(
-    {
-      did: params.did,
-      publication_name: decodeURIComponent(params.publication),
-    },
-    { supabase: supabaseServerClient },
-  );
+  const params = await props.params;
+  const did = decodeURIComponent(params.did);
+  const publication = decodeURIComponent(params.publication);
+  const feed = await generateFeed(did, publication);
 
-  let pubRecord = publication?.record as PubLeafletPublication.Record;
-  if (!publication || !pubRecord)
-    return new NextResponse(null, { status: 404 });
+  if (feed instanceof NextResponse) {
+    return feed;
+  }
 
-  const feed = new Feed({
-    title: pubRecord.name,
-    description: pubRecord.description,
-    id: `https://${pubRecord.base_path}`,
-    link: `https://${pubRecord.base_path}`,
-    language: "en", // optional, used only in RSS 2.0, possible values: http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
-    copyright: "",
-    feedLinks: {
-      rss: `https://${pubRecord.base_path}/rss`,
-      atom: `https://${pubRecord.base_path}/atom`,
-      json: `https://${pubRecord.base_path}/json`,
-    },
-  });
-
-  await Promise.all(
-    publication?.documents_in_publications.map(async (doc) => {
-      if (!doc.documents) return;
-      let record = doc.documents?.data as PubLeafletDocument.Record;
-      let uri = new AtUri(doc.documents?.uri);
-      let rkey = uri.rkey;
-      if (!record) return;
-      let firstPage = record.pages[0];
-      let blocks: PubLeafletPagesLinearDocument.Block[] = [];
-      if (PubLeafletPagesLinearDocument.isMain(firstPage)) {
-        blocks = firstPage.blocks || [];
-      }
-      let stream = await renderToReadableStream(
-        createElement(StaticPostContent, { blocks, did: uri.host }),
-      );
-      const reader = stream.getReader();
-      const chunks = [];
-
-      let done, value;
-      while (!done) {
-        ({ done, value } = await reader.read());
-        if (value) {
-          chunks.push(new TextDecoder().decode(value));
-        }
-      }
-
-      feed.addItem({
-        title: record.title,
-        description: record.description,
-        date: record.publishedAt ? new Date(record.publishedAt) : new Date(),
-        id: `https://${pubRecord.base_path}/${rkey}`,
-        link: `https://${pubRecord.base_path}/${rkey}`,
-        content: chunks.join(""),
-      });
-    }),
-  );
   return new Response(feed.json1(), {
     headers: {
       "Content-Type": "application/feed+json",

--- a/app/lish/[did]/[publication]/json/route.ts
+++ b/app/lish/[did]/[publication]/json/route.ts
@@ -84,9 +84,9 @@ export async function GET(
       });
     }),
   );
-  return new Response(feed.rss2(), {
+  return new Response(feed.json1(), {
     headers: {
-      "Content-Type": "application/rss+xml",
+      "Content-Type": "application/feed+json",
     },
   });
 }

--- a/app/lish/[did]/[publication]/layout.ts
+++ b/app/lish/[did]/[publication]/layout.ts
@@ -1,0 +1,114 @@
+import { AtUri } from "@atproto/syntax";
+import { Feed } from "feed";
+import {
+  PubLeafletDocument,
+  PubLeafletPagesLinearDocument,
+  PubLeafletPublication,
+} from "lexicons/api";
+import { createElement } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { StaticPostContent } from "./[rkey]/StaticPostContent";
+import { get_publication_data } from "app/api/rpc/[command]/get_publication_data";
+import { supabaseServerClient } from "supabase/serverClient";
+import { NextResponse } from "next/server";
+import { Metadata } from "next";
+
+export async function generatePublicationMetadata(
+  did: string,
+  publication_name: string,
+): Promise<Metadata | undefined> {
+  let { result: publication } = await get_publication_data.handler(
+    {
+      did: did,
+      publication_name: publication_name,
+    },
+    { supabase: supabaseServerClient },
+  );
+  if (!publication) return undefined;
+
+  let pubRecord = publication?.record as PubLeafletPublication.Record;
+
+  return {
+    title: pubRecord?.name || "Untitled Publication",
+    description: pubRecord?.description || "",
+    alternates: pubRecord?.base_path
+      ? {
+          types: {
+            "application/rss+xml": `https://${pubRecord?.base_path}/rss`,
+            "application/atom+xml": `https://${pubRecord?.base_path}/atom`,
+            "application/json": `https://${pubRecord?.base_path}/json`,
+          },
+        }
+      : undefined,
+  };
+}
+
+export async function generateFeed(
+  did: string,
+  publication_name: string,
+): Promise<Feed | NextResponse<unknown>> {
+  let { result: publication } = await get_publication_data.handler(
+    {
+      did: did,
+      publication_name: publication_name,
+    },
+    { supabase: supabaseServerClient },
+  );
+
+  let pubRecord = publication?.record as PubLeafletPublication.Record;
+  if (!publication || !pubRecord)
+    return new NextResponse(null, { status: 404 });
+
+  const feed = new Feed({
+    title: pubRecord.name,
+    description: pubRecord.description,
+    id: `https://${pubRecord.base_path}`,
+    link: `https://${pubRecord.base_path}`,
+    language: "en", // optional, used only in RSS 2.0, possible values: http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
+    copyright: "",
+    feedLinks: {
+      rss: `https://${pubRecord.base_path}/rss`,
+      atom: `https://${pubRecord.base_path}/atom`,
+      json: `https://${pubRecord.base_path}/json`,
+    },
+  });
+
+  await Promise.all(
+    publication.documents_in_publications.map(async (doc) => {
+      if (!doc.documents) return;
+      let record = doc.documents?.data as PubLeafletDocument.Record;
+      let uri = new AtUri(doc.documents?.uri);
+      let rkey = uri.rkey;
+      if (!record) return;
+      let firstPage = record.pages[0];
+      let blocks: PubLeafletPagesLinearDocument.Block[] = [];
+      if (PubLeafletPagesLinearDocument.isMain(firstPage)) {
+        blocks = firstPage.blocks || [];
+      }
+      let stream = await renderToReadableStream(
+        createElement(StaticPostContent, { blocks, did: uri.host }),
+      );
+      const reader = stream.getReader();
+      const chunks = [];
+
+      let done, value;
+      while (!done) {
+        ({ done, value } = await reader.read());
+        if (value) {
+          chunks.push(new TextDecoder().decode(value));
+        }
+      }
+
+      feed.addItem({
+        title: record.title,
+        description: record.description,
+        date: record.publishedAt ? new Date(record.publishedAt) : new Date(),
+        id: `https://${pubRecord.base_path}/${rkey}`,
+        link: `https://${pubRecord.base_path}/${rkey}`,
+        content: chunks.join(""),
+      });
+    }),
+  );
+
+  return feed;
+}

--- a/app/lish/[did]/[publication]/layout.tsx
+++ b/app/lish/[did]/[publication]/layout.tsx
@@ -13,18 +13,25 @@ import { supabaseServerClient } from "supabase/serverClient";
 import { NextResponse } from "next/server";
 import { Metadata } from "next";
 
-export async function generatePublicationMetadata(
-  did: string,
-  publication_name: string,
-): Promise<Metadata | undefined> {
+export default async function PublicationLayout(props: {
+  children: React.ReactNode;
+}) {
+  return <>{props.children}</>;
+}
+
+export async function generateMetadata(params: {
+  did: string;
+  publication: string;
+}): Promise<Metadata> {
+  if (!params.did || !params.publication) return { title: "Publication 404" };
   let { result: publication } = await get_publication_data.handler(
     {
-      did: did,
-      publication_name: publication_name,
+      did: decodeURIComponent(params.did),
+      publication_name: decodeURIComponent(params.publication),
     },
     { supabase: supabaseServerClient },
   );
-  if (!publication) return undefined;
+  if (!publication) return { title: "Publication 404" };
 
   let pubRecord = publication?.record as PubLeafletPublication.Record;
 

--- a/app/lish/[did]/[publication]/page.tsx
+++ b/app/lish/[did]/[publication]/page.tsx
@@ -1,5 +1,4 @@
 import { supabaseServerClient } from "supabase/serverClient";
-import { Metadata } from "next";
 import { AtUri } from "@atproto/syntax";
 import { PubLeafletDocument, PubLeafletPublication } from "lexicons/api";
 import Link from "next/link";
@@ -11,25 +10,6 @@ import {
   PublicationBackgroundProvider,
   PublicationThemeProvider,
 } from "components/ThemeManager/PublicationThemeProvider";
-import { generatePublicationMetadata } from "./layout";
-
-export async function generateMetadata(props: {
-  params: Promise<{ publication: string; did: string }>;
-}): Promise<Metadata> {
-  let params = await props.params;
-
-  let did = decodeURIComponent(params.did);
-  if (!did) return { title: "Publication 404" };
-  let publication_name = decodeURIComponent(params.publication);
-  if (!publication_name) return { title: "Publication 404" };
-
-  let metadata = await generatePublicationMetadata(did, publication_name);
-  if (!metadata) {
-    return { title: "Publication 404" };
-  } else {
-    return metadata;
-  }
-}
 
 export default async function Publication(props: {
   params: Promise<{ publication: string; did: string }>;

--- a/app/lish/[did]/[publication]/page.tsx
+++ b/app/lish/[did]/[publication]/page.tsx
@@ -43,6 +43,8 @@ export async function generateMetadata(props: {
       ? {
           types: {
             "application/rss+xml": `https://${record?.base_path}/rss`,
+            "application/atom+xml": `https://${record?.base_path}/atom`,
+            "application/json": `https://${record?.base_path}/json`,
           },
         }
       : undefined,

--- a/app/lish/[did]/[publication]/rss/route.ts
+++ b/app/lish/[did]/[publication]/rss/route.ts
@@ -1,16 +1,5 @@
-import { AtUri } from "@atproto/syntax";
-import { get_publication_data } from "app/api/rpc/[command]/get_publication_data";
-import { Feed } from "feed";
-import fs from "fs/promises";
-import {
-  PubLeafletDocument,
-  PubLeafletPagesLinearDocument,
-  PubLeafletPublication,
-} from "lexicons/api";
-import { NextRequest, NextResponse } from "next/server";
-import { createElement } from "react";
-import { supabaseServerClient } from "supabase/serverClient";
-import { StaticPostContent } from "../[rkey]/StaticPostContent";
+import { NextResponse } from "next/server";
+import { generateFeed } from "../layout";
 
 export async function GET(
   req: Request,
@@ -21,69 +10,15 @@ export async function GET(
   let renderToReadableStream = await import("react-dom/server").then(
     (module) => module.renderToReadableStream,
   );
-  let params = await props.params;
-  let { result: publication } = await get_publication_data.handler(
-    {
-      did: params.did,
-      publication_name: decodeURIComponent(params.publication),
-    },
-    { supabase: supabaseServerClient },
-  );
+  const params = await props.params;
+  const did = decodeURIComponent(params.did);
+  const publication = decodeURIComponent(params.publication);
+  const feed = await generateFeed(did, publication);
 
-  let pubRecord = publication?.record as PubLeafletPublication.Record;
-  if (!publication || !pubRecord)
-    return new NextResponse(null, { status: 404 });
+  if (feed instanceof NextResponse) {
+    return feed;
+  }
 
-  const feed = new Feed({
-    title: pubRecord.name,
-    description: pubRecord.description,
-    id: `https://${pubRecord.base_path}`,
-    link: `https://${pubRecord.base_path}`,
-    language: "en", // optional, used only in RSS 2.0, possible values: http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
-    copyright: "",
-    feedLinks: {
-      rss: `https://${pubRecord.base_path}/rss`,
-      atom: `https://${pubRecord.base_path}/atom`,
-      json: `https://${pubRecord.base_path}/json`,
-    },
-  });
-
-  await Promise.all(
-    publication?.documents_in_publications.map(async (doc) => {
-      if (!doc.documents) return;
-      let record = doc.documents?.data as PubLeafletDocument.Record;
-      let uri = new AtUri(doc.documents?.uri);
-      let rkey = uri.rkey;
-      if (!record) return;
-      let firstPage = record.pages[0];
-      let blocks: PubLeafletPagesLinearDocument.Block[] = [];
-      if (PubLeafletPagesLinearDocument.isMain(firstPage)) {
-        blocks = firstPage.blocks || [];
-      }
-      let stream = await renderToReadableStream(
-        createElement(StaticPostContent, { blocks, did: uri.host }),
-      );
-      const reader = stream.getReader();
-      const chunks = [];
-
-      let done, value;
-      while (!done) {
-        ({ done, value } = await reader.read());
-        if (value) {
-          chunks.push(new TextDecoder().decode(value));
-        }
-      }
-
-      feed.addItem({
-        title: record.title,
-        description: record.description,
-        date: record.publishedAt ? new Date(record.publishedAt) : new Date(),
-        id: `https://${pubRecord.base_path}/${rkey}`,
-        link: `https://${pubRecord.base_path}/${rkey}`,
-        content: chunks.join(""),
-      });
-    }),
-  );
   return new Response(feed.rss2(), {
     headers: {
       "Content-Type": "application/rss+xml",


### PR DESCRIPTION
This pull request adds alternative links for feeds to the page of individual articles, fixes a MIME type mismatch on the RSS feed route ("text/xml" vs "application/rss+xml") and adds Atom and JSON feeds for alternatives to the RSS 2.0 standard.