### PR TITLE
RSS link: add text for screen readers, add aria-hidden to svg

### DIFF
--- a/app/lish/Subscribe.tsx
+++ b/app/lish/Subscribe.tsx
@@ -218,7 +218,8 @@ export const SubscribeWithBluesky = (props: {
           setSuccessModalOpen={setSuccessModalOpen}
         />
         <a href={`${props.base_url}/rss`} className="flex" target="_blank">
-          <RSSSmall className="self-center" />
+          <span className="sr-only">Subscribe to RSS</span>
+          <RSSSmall className="self-center" aria-hidden />
         </a>
       </div>
     </div>


### PR DESCRIPTION
This PR resolves an issue with the RSS link, which does not have readable text (just an svg).

Summary of changes:
- add text to describe the RSS link with sr-only tailwind class so the text is not visible & can still be read by screen readers
- add aria-hidden to the RSS svg, because the svg has no title or aria-label on its own (rather, it's labeled by the sr-only text in the shared parent)

Thank you!
