### PR TITLE
Fix background color on iOS

### DIFF
--- a/components/ThemeManager/ThemeProvider.tsx
+++ b/components/ThemeManager/ThemeProvider.tsx
@@ -185,6 +185,7 @@ export const BaseThemeProvider = ({
     if (!el) return;
     setCSSVariableToColor(el, "--bg-leaflet", bgLeaflet);
     setCSSVariableToColor(el, "--bg-page", bgPage);
+    document.body.style.backgroundColor = `rgb(${colorToString(bgLeaflet, "rgb")})`;
     document
       .querySelector('meta[name="theme-color"]')
       ?.setAttribute("content", `rgb(${colorToString(bgLeaflet, "rgb")})`);


### PR DESCRIPTION
Before you pull, have you made sure...
- it looks good on both mobile and desktop
- it undo's like it ought to
- it handles keyboard interactions reasonably well
- it behaves as you would expect if you lock it
- no build errors!!!

---

This change should fix the background color not being set properly. This will impact how the app looks on (at least) iOS devices since the upper and lower areas of the screen inherit the color of the body of the document. This issue primarily affects docs/publications that use a darker colorscheme, since the body was always set to white.

Note: I was unable to test if this works with publications since I do not know how to get them working on my local machine. I tested (by looking) the home page and a document page.

Below are images of the changes:
| | | | | |
|-|-|-|-|-|
| ![IMG_9947 Large](https://github.com/user-attachments/assets/8d58da38-4a2e-429a-9e9b-25edd7be472a) | ![IMG_9949 Large](https://github.com/user-attachments/assets/bf4b7795-b5d9-45df-80ea-91adcd5ae949) | ![IMG_9946 Large](https://github.com/user-attachments/assets/3e1653c2-4d83-4443-8d0c-e1ed94d13ba0) | ![IMG_9945 Large](https://github.com/user-attachments/assets/5201ca05-f619-47ff-b664-1fc499ffa704) | ![IMG_9948 Large](https://github.com/user-attachments/assets/cb5ff21d-0a41-4bc1-8d01-1d038a51e420) |

Before images:
| | |
|-|-|
| ![IMG_9951 Large](https://github.com/user-attachments/assets/66c974b2-7bdf-43db-b077-54e68c0805d7) | ![IMG_9950 Large](https://github.com/user-attachments/assets/13a831bf-f0bd-49b3-ae53-5492fbc8212e) |

