### PR TITLE
Fix broken "New publication" link

### DIFF
--- a/components/ActionBar/Publications.tsx
+++ b/components/ActionBar/Publications.tsx
@@ -37,7 +37,7 @@ export const PublicationButtons = (props: {
         );
       })}
       <Link
-        href={"./lish/createPub"}
+        href={"/lish/createPub"}
         className="pubListCreateNew  text-accent-contrast text-sm place-self-end hover:text-accent-contrast"
       >
         New


### PR DESCRIPTION
It was pointing to https://leaflet.pub/lish/did:plc:fpruhuo22xkm5o7ttr2ktxdo/3m23dstduds2v/lish/createPub for me, which is not what we want.

<img width="1001" height="545" alt="Screenshot 2025-10-09 at 23 10 38" src="https://github.com/user-attachments/assets/b1e26a97-2f5e-4c39-98e3-7d84b863b821" />
