### PR TITLE
Fix block command bar ESC key handling

### DIFF
--- a/components/Blocks/BlockCommandBar.tsx
+++ b/components/Blocks/BlockCommandBar.tsx
@@ -6,7 +6,7 @@ import { useEntitySetContext } from "components/EntitySetProvider";
 import { NestedCardThemeProvider } from "components/ThemeManager/ThemeProvider";
 import { UndoManager } from "src/undoManager";
 import { useLeafletPublicationData } from "components/PageSWRDataProvider";
-import { useEditorStates } from "src/state/useEditorState";
+import { setEditorState, useEditorStates } from "src/state/useEditorState";
 
 type Props = {
   parent: string;
@@ -36,24 +36,14 @@ export const BlockCommandBar = ({
   // This clears '/' AND anything typed after it
   const clearCommandSearchText = () => {
     if (!props.entityID) return;
-    useEditorStates.setState((s) => {
-      let existingState = s.editorStates[props.entityID!];
-      if (!existingState) {
-        return s;
-      }
+    const entityID = props.entityID;
+    
+    const existingState = useEditorStates.getState().editorStates[entityID];
+    if (!existingState) return;
 
-      let tr = existingState.editor.tr;
-      tr.deleteRange(1, tr.doc.content.size - 1);
-      return {
-        editorStates: {
-          ...s.editorStates,
-          [props.entityID!]: {
-            ...existingState,
-            editor: existingState.editor.apply(tr),
-          },
-        },
-      };
-    });
+    const tr = existingState.editor.tr;
+    tr.deleteRange(1, tr.doc.content.size - 1);
+    setEditorState(entityID, { editor: existingState.editor.apply(tr) });
   };
 
   let commandResults = blockCommands.filter((command) => {


### PR DESCRIPTION
Fixes https://tangled.org/@leaflet.pub/leaflet/issues/5 (sorry, I haven't figured out tangled yet 🫣)

## Summary

The ESC key wasn't working to close the command bar. The `Popover.Root` was controlled with `open` but was missing an `onOpenChange` handler, so Radix couldn't actually close it when ESC was pressed. See the relevant Radix documentation [here](https://www.radix-ui.com/primitives/docs/components/popover#root).

- Added `clearCommandSearchText` to ensure editor state will remove '/' and anything typed after it.
- Tested to make sure clicking outside still closes the command bar.
- Was unable to test tapping behaviour on mobile.
