### PR TITLE
Fix bluesky link not clickable in post content

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
# Summary

The invisible overlay button that opens threads was sitting on top of the bluesky link icon due to CSS stacking order. Added z-[-1] to push it behind the content where it belongs.

I was unable to test the solution locally due to lack of test data.

GIF of the current broken behaviour for further context:

![CleanShot 2026-01-31 at 12  06 58](https://github.com/user-attachments/assets/964e4574-4800-4a08-9515-817a6e2efb11)
