### PR TITLE
Fix missing 'of' in Bluesky mentions copy

### DIFF
--- a/app/lish/[did]/[publication]/dashboard/settings/PostOptions.tsx
+++ b/app/lish/[did]/[publication]/dashboard/settings/PostOptions.tsx
@@ -105,7 +105,7 @@ export const PostOptions = (props: {
           <div className="flex flex-col justify-start">
             <div className="font-bold">Show Mentions</div>
             <div className="text-tertiary text-sm leading-tight">
-              Display a list Bluesky mentions about your post
+              Display a list of Bluesky mentions about your post
             </div>
           </div>
         </Toggle>

--- a/components/PostSettings.tsx
+++ b/components/PostSettings.tsx
@@ -74,7 +74,7 @@ export function PostSettings() {
             <div className="flex flex-col justify-start">
               <div className="font-bold">Show Mentions</div>
               <div className="text-tertiary text-sm leading-tight">
-                Display a list Bluesky mentions about your post
+                Display a list of Bluesky mentions about your post
               </div>
             </div>
           </Toggle>


### PR DESCRIPTION
Add the missing "of" between "list" and "Bluesky" in the "Show Mentions"
toggle description across both PostSettings and PostOptions components.

Changes:
- components/PostSettings.tsx: "Display a list Bluesky mentions..." → "Display a list of Bluesky mentions..."
- app/lish/[did]/[publication]/dashboard/settings/PostOptions.tsx: Same fix

https://claude.ai/code/session_01UmMsAY9kbwJy4p1nD6sCh8