### PR TITLE
fix: copy post link button

### DIFF
--- a/components/InteractionsPreview.tsx
+++ b/components/InteractionsPreview.tsx
@@ -77,7 +77,7 @@ export const InteractionPreview = (props: {
               let mouseY = e.clientY;
 
               if (!props.postUrl) return;
-              navigator.clipboard.writeText(`leaflet.pub${props.postUrl}`);
+              navigator.clipboard.writeText(props.postUrl);
 
               smoker({
                 text: <strong>Copied Link!</strong>,


### PR DESCRIPTION
When clicking on a share button, we're getting this sort of thing copied to the clipboard: leaflet.pubhttps://pfrazee.leaflet.pub/3mbnbdt4bas2a

This PR should fix it 🤞 