### PR TITLE
fix: post href

### DIFF
--- a/app/lish/[did]/[publication]/dashboard/PublishedPostsLists.tsx
+++ b/app/lish/[did]/[publication]/dashboard/PublishedPostsLists.tsx
@@ -144,7 +144,7 @@ function PublishedPostItem(props: {
               showComments={pubRecord?.preferences?.showComments !== false}
               showMentions={pubRecord?.preferences?.showMentions !== false}
               showRecommends={pubRecord?.preferences?.showRecommends !== false}
-              postUrl={`${getPublicationURL(publication)}/${uri.rkey}`}
+              postUrl={`${getPublicationURL(publication)}${doc.record.path ?? `/${uri.rkey}`}`}
             />
           </div>
         </div>

--- a/app/lish/[did]/[publication]/page.tsx
+++ b/app/lish/[did]/[publication]/page.tsx
@@ -168,7 +168,7 @@ export default async function Publication(props: {
                             recommendsCount={recommends}
                             documentUri={doc.documents.uri}
                             tags={tags}
-                            postUrl={`${getPublicationURL(publication)}/${uri.rkey}`}
+                            postUrl={`${getPublicationURL(publication)}${doc_record.path ?? `/${uri.rkey}`}`}
                             showComments={
                               record?.preferences?.showComments !== false
                             }

--- a/components/PostListing.tsx
+++ b/components/PostListing.tsx
@@ -61,7 +61,7 @@ export const PostListing = (props: Post) => {
 
   // For standalone posts, link directly to the document
   let postHref = props.publication
-    ? `${props.publication.href}/${postUri.rkey}`
+    ? `${props.publication.href}${postRecord.path ?? `/${postUri.rkey}`}`
     : `/p/${postUri.host}/${postUri.rkey}`;
 
   return (


### PR DESCRIPTION
Fixes the post hrefs to work with site.standard.document's whose path is not the same as the record key.

Ideally, this logic should be reused, but I'm not knowledgeable enough with the codebase to know where to put it. Or ensured that `path` is defined since it's required according to the specification, and remove the `??` fallback.