### PR TITLE
Fix swipe gesture conflicting with text selection on mobile

### DIFF
--- a/components/Blocks/Block.tsx
+++ b/components/Blocks/Block.tsx
@@ -121,11 +121,15 @@ export const Block = memo(function Block(
   // THIS IS WHERE YOU SET WHETHER OR NOT AREYOUSURE IS TRIGGERED ON THE DELETE KEY
   useBlockKeyboardHandlers(props, areYouSure, setAreYouSure);
 
+  const swipeEnabled = isMobile && !!props.listData;
   const bindSwipe = useDrag(
     ({ last, movement: [mx] }) => {
       if (!last) return;
       if (!rep || !props.listData || !entity_set.permissions.write) return;
       if (Math.abs(mx) < SWIPE_THRESHOLD) return;
+      // Don't trigger indent/outdent if the user is selecting text
+      let selection = window.getSelection();
+      if (selection && !selection.isCollapsed) return;
       let { foldedBlocks, toggleFold } = useUIState.getState();
       if (mx > 0) {
         if (props.previousBlock) {
@@ -144,8 +148,7 @@ export const Block = memo(function Block(
     {
       axis: "x",
       filterTaps: true,
-      pointer: { touch: true },
-      enabled: isMobile && !!props.listData,
+      enabled: swipeEnabled,
     },
   );
 
@@ -172,7 +175,7 @@ export const Block = memo(function Block(
         flex flex-row gap-2
         px-3 sm:px-4
         z-1 w-full
-        ${props.listData ? "touch-pan-y" : ""}
+        ${swipeEnabled ? "touch-pan-y" : ""}
       ${alignmentStyle}
       ${
         !props.nextBlock

--- a/components/Blocks/Block.tsx
+++ b/components/Blocks/Block.tsx
@@ -123,7 +123,16 @@ export const Block = memo(function Block(
 
   const swipeEnabled = isMobile && !!props.listData;
   const bindSwipe = useDrag(
-    ({ last, movement: [mx] }) => {
+    ({ last, movement: [mx], cancel, first }) => {
+      // Cancel the gesture immediately if there's an active text selection,
+      // so we don't interfere with native selection handle dragging
+      if (first) {
+        let selection = window.getSelection();
+        if (selection && !selection.isCollapsed) {
+          cancel();
+          return;
+        }
+      }
       if (!last) return;
       if (!rep || !props.listData || !entity_set.permissions.write) return;
       if (Math.abs(mx) < SWIPE_THRESHOLD) return;
@@ -149,13 +158,30 @@ export const Block = memo(function Block(
       axis: "x",
       filterTaps: true,
       enabled: swipeEnabled,
+      // Disable pointer capture to prevent stealing pointer events from
+      // native text selection handles on mobile. Without this, setPointerCapture()
+      // routes all pointer events to the block div, breaking selection handle
+      // dragging (especially on fast movements).
+      pointer: { capture: false },
     },
   );
 
   return (
     <div
       {...(!props.preview ? { ...mouseHandlers, ...longPressHandlers } : {})}
-      {...bindSwipe()}
+      {...(() => {
+        const swipeHandlers = bindSwipe();
+        // Merge onPointerDown from swipe gesture with longPressHandlers
+        // to avoid bindSwipe() overriding useLongPress's onPointerDown
+        if (!props.preview && swipeEnabled && longPressHandlers.onPointerDown) {
+          const swipeOnPointerDown = swipeHandlers.onPointerDown;
+          swipeHandlers.onPointerDown = (e: React.PointerEvent) => {
+            longPressHandlers.onPointerDown(e as unknown as React.MouseEvent);
+            if (swipeOnPointerDown) swipeOnPointerDown(e);
+          };
+        }
+        return swipeHandlers;
+      })()}
       id={
         !props.preview ? elementId.block(props.entityID).container : undefined
       }

--- a/components/Blocks/Block.tsx
+++ b/components/Blocks/Block.tsx
@@ -9,6 +9,10 @@ import { useLongPress } from "src/hooks/useLongPress";
 import { focusBlock } from "src/utils/focusBlock";
 import { useHandleDrop } from "./useHandleDrop";
 import { useEntitySetContext } from "components/EntitySetProvider";
+import { indent, outdent } from "src/utils/list-operations";
+import { useDrag } from "@use-gesture/react";
+
+const SWIPE_THRESHOLD = 50;
 
 import { TextBlock } from "./TextBlock/index";
 import { ImageBlock } from "./ImageBlock";
@@ -76,6 +80,8 @@ export const Block = memo(function Block(
     nextPosition: props.nextPosition,
   });
   let entity_set = useEntitySetContext();
+  let isMobile = useIsMobile();
+  let { rep } = useReplicache();
 
   let { isLongPress, longPressHandlers } = useLongPress(() => {
     if (isTextBlock[props.type]) return;
@@ -115,9 +121,38 @@ export const Block = memo(function Block(
   // THIS IS WHERE YOU SET WHETHER OR NOT AREYOUSURE IS TRIGGERED ON THE DELETE KEY
   useBlockKeyboardHandlers(props, areYouSure, setAreYouSure);
 
+  const bindSwipe = useDrag(
+    ({ last, movement: [mx] }) => {
+      if (!last) return;
+      if (!rep || !props.listData || !entity_set.permissions.write) return;
+      if (Math.abs(mx) < SWIPE_THRESHOLD) return;
+      let { foldedBlocks, toggleFold } = useUIState.getState();
+      if (mx > 0) {
+        if (props.previousBlock) {
+          indent(props, props.previousBlock, rep, {
+            foldedBlocks,
+            toggleFold,
+          });
+        }
+      } else {
+        outdent(props, props.previousBlock, rep, {
+          foldedBlocks,
+          toggleFold,
+        });
+      }
+    },
+    {
+      axis: "x",
+      filterTaps: true,
+      pointer: { touch: true },
+      enabled: isMobile && !!props.listData,
+    },
+  );
+
   return (
     <div
       {...(!props.preview ? { ...mouseHandlers, ...longPressHandlers } : {})}
+      {...bindSwipe()}
       id={
         !props.preview ? elementId.block(props.entityID).container : undefined
       }
@@ -137,6 +172,7 @@ export const Block = memo(function Block(
         flex flex-row gap-2
         px-3 sm:px-4
         z-1 w-full
+        ${props.listData ? "touch-pan-y" : ""}
       ${alignmentStyle}
       ${
         !props.nextBlock
@@ -496,7 +532,6 @@ export const ListMarker = (
     className?: string;
   },
 ) => {
-  let isMobile = useIsMobile();
   let checklist = useEntity(props.value, "block/check-list");
   let listStyle = useEntity(props.value, "block/list-style");
   let headingLevel = useEntity(props.value, "block/heading-level")?.data.value;
@@ -511,7 +546,6 @@ export const ListMarker = (
 
   let [editingNumber, setEditingNumber] = useState(false);
   let [numberInputValue, setNumberInputValue] = useState("");
-
   useEffect(() => {
     if (!editingNumber) {
       setNumberInputValue("");
@@ -545,6 +579,7 @@ export const ListMarker = (
 
     setEditingNumber(false);
   };
+
   return (
     <div
       className={`shrink-0  flex justify-end items-center h-3 z-1

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@tinybirdco/sdk": "^0.0.55",
         "@tiptap/core": "^2.11.5",
         "@types/mdx": "^2.0.13",
+        "@use-gesture/react": "^10.3.1",
         "@vercel/analytics": "^1.5.0",
         "@vercel/functions": "^2.2.12",
         "@vercel/sdk": "^1.11.4",
@@ -8957,6 +8958,24 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@vercel/analytics": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@tinybirdco/sdk": "^0.0.55",
     "@tiptap/core": "^2.11.5",
     "@types/mdx": "^2.0.13",
+    "@use-gesture/react": "^10.3.1",
     "@vercel/analytics": "^1.5.0",
     "@vercel/functions": "^2.2.12",
     "@vercel/sdk": "^1.11.4",


### PR DESCRIPTION
## Summary

- **Remove `pointer: { touch: true }`** from `@use-gesture/react`'s `useDrag` config, switching from TouchEvent mode to the default PointerEvent mode. TouchEvent mode adds non-passive `touchmove` listeners that call `preventDefault()` and block the browser's compositor thread — this is what causes text selection handles to break during fast drags on Android/iOS.
- **Only apply `touch-pan-y` CSS when the swipe gesture is actually enabled** (mobile + list items), rather than on all list blocks including desktop.
- **Add a selection guard** to skip indent/outdent when text is actively selected, preventing accidental list operations during text selection.

## Root Cause

The `pointer: { touch: true }` option in `@use-gesture/react` forces the library to use raw `TouchEvent` listeners instead of `PointerEvent`. In TouchEvent mode, the library adds **non-passive** `touchmove` handlers that call `event.preventDefault()` during active gestures. This blocks the browser's compositor thread — on Android Chrome especially, this means the browser can't update selection handle positions fast enough during quick drags, causing it to lose track of the handle and "break" the selection.

The default PointerEvent mode instead uses `touch-action` CSS to communicate with the compositor about which axes JS handles, keeping the compositor thread unblocked and native behaviors (like selection handles) working correctly.

## Test plan

- [ ] On Android: long-press to select text in a list item, then drag the selection handle quickly — selection should track smoothly
- [ ] On iOS: same test — selection handles should work without breaking
- [ ] On mobile: swipe right on a list item to indent, swipe left to outdent — should still work
- [ ] On desktop: verify no regression in list behavior or text selection

https://claude.ai/code/session_01AMC5Grk2NArBJJ4RHktNQU