### PR TITLE
Fix bskyPostRef and coverImage being dropped on post updates

### DIFF
--- a/actions/publishToPublication.ts
+++ b/actions/publishToPublication.ts
@@ -182,7 +182,9 @@ export async function publishToPublication({
     credentialSession.did!,
   );
 
-  let existingRecord: Partial<PubLeafletDocument.Record> = {};
+  let existingRecord: Partial<PubLeafletDocument.Record> & {
+    bskyPostRef?: SiteStandardDocument.Record["bskyPostRef"];
+  } = {};
   const normalizedDoc = normalizeDocumentRecord(draft?.documents?.data);
   if (normalizedDoc) {
     // When reading existing data, use normalized format to extract fields
@@ -194,6 +196,7 @@ export async function publishToPublication({
       tags: normalizedDoc.tags,
       coverImage: normalizedDoc.coverImage,
       theme: normalizedDoc.theme,
+      bskyPostRef: normalizedDoc.bskyPostRef,
     };
   }
 
@@ -258,6 +261,9 @@ export async function publishToPublication({
     const siteUri =
       publication_uri || `https://leaflet.pub/p/${credentialSession.did}`;
 
+    // Preserve existing cover image BlobRef if no new one was uploaded
+    const resolvedCoverImage = coverImageBlob || existingRecord.coverImage;
+
     record = {
       $type: "site.standard.document",
       title: title || "",
@@ -267,7 +273,7 @@ export async function publishToPublication({
         publishedAt || existingRecord.publishedAt || new Date().toISOString(),
       ...(description && { description }),
       ...(tags !== undefined && { tags }),
-      ...(coverImageBlob && { coverImage: coverImageBlob }),
+      ...(resolvedCoverImage && { coverImage: resolvedCoverImage }),
       // Include theme for standalone documents (not for publication documents)
       ...(!publication_uri && theme && { theme }),
       ...(preferences && {
@@ -276,6 +282,10 @@ export async function publishToPublication({
           ...preferences,
         },
       }),
+      // Preserve existing Bluesky post reference on update
+      ...(existingRecord.bskyPostRef && {
+        bskyPostRef: existingRecord.bskyPostRef,
+      }),
       content: {
         $type: "pub.leaflet.content" as const,
         pages: pagesArray,
@@ -283,6 +293,11 @@ export async function publishToPublication({
     } satisfies SiteStandardDocument.Record;
   } else {
     // pub.leaflet.document format (legacy)
+    // Preserve existing cover image BlobRef if no new one was uploaded
+    const resolvedCoverImage = coverImageBlob || existingRecord.coverImage;
+    // Convert normalized bskyPostRef back to legacy postRef field
+    const existingPostRef = existingRecord.bskyPostRef;
+
     record = {
       $type: "pub.leaflet.document",
       author: credentialSession.did!,
@@ -297,7 +312,9 @@ export async function publishToPublication({
       title: title || "",
       description: description || "",
       ...(tags !== undefined && { tags }),
-      ...(coverImageBlob && { coverImage: coverImageBlob }),
+      ...(resolvedCoverImage && { coverImage: resolvedCoverImage }),
+      // Preserve existing Bluesky post reference on update
+      ...(existingPostRef && { postRef: existingPostRef }),
       pages: pagesArray,
       publishedAt:
         publishedAt || existingRecord.publishedAt || new Date().toISOString(),


### PR DESCRIPTION
## Summary

- **Fix `bskyPostRef` being silently dropped on every post update** — the existing Bluesky post reference was extracted by `normalizeDocumentRecord` but never included in `existingRecord` or written back into the new record, so every update removed the Bluesky post link
- **Fix `coverImage` BlobRef being dropped on update** when no new cover image is uploaded — now falls back to the existing cover image from the previous record
- Both fixes apply to `site.standard.document` (new format) and `pub.leaflet.document` (legacy format)

## What was happening

In `publishToPublication()`, when updating an existing post:

1. The normalized document was read and fields like `publishedAt`, `title`, `tags`, `coverImage`, `theme` were extracted into `existingRecord` — but `bskyPostRef` was omitted
2. When constructing the new record, `bskyPostRef`/`postRef` was never included, silently removing the Bluesky cross-post reference
3. `coverImage` only used a freshly uploaded blob (`coverImageBlob`) with no fallback to the existing BlobRef, so if no new image was uploaded the cover image was also dropped

## Test plan

- [ ] Publish a post with a Bluesky cross-post, then update the post content — verify `bskyPostRef` is preserved in the AT Proto record
- [ ] Publish a post with a cover image, then update the post without changing the cover image — verify the cover image persists
- [ ] Publish a new post for the first time — verify `bskyPostRef` is still correctly set by `publishPostToBsky` after initial publish
- [ ] Update a legacy `pub.leaflet.document` post — verify `postRef` is preserved

https://claude.ai/code/session_01UwRRGEFraEHAL1xa5FSDr2