### PR TITLE
fix(scopes): use account:email scope over transition:email

### DIFF
--- a/app/api/oauth/[route]/oauth-metadata.ts
+++ b/app/api/oauth/[route]/oauth-metadata.ts
@@ -8,7 +8,7 @@ const hostname =
     : "https://leaflet.pub";
 
 const scope =
-  "atproto account:email?action=read include:pub.leaflet.authFullPermissions include:site.standard.authFull include:app.bsky.authCreatePosts include:app.bsky.authViewAll?aud=did:web:api.bsky.app%23bsky_appview rpc:parts.page.mention.search?aud=* blob:*/*";
+  "atproto transition:email account:email?action=read include:pub.leaflet.authFullPermissions include:site.standard.authFull include:app.bsky.authCreatePosts include:app.bsky.authViewAll?aud=did:web:api.bsky.app%23bsky_appview rpc:parts.page.mention.search?aud=* blob:*/*";
 const localconfig: OAuthClientMetadataInput = {
   client_id: `http://localhost/?redirect_uri=${encodeURI(`http://127.0.0.1:3000/api/oauth/callback`)}&scope=${encodeURIComponent(scope)}`,
   client_name: `Leaflet`,

--- a/app/api/oauth/[route]/oauth-metadata.ts
+++ b/app/api/oauth/[route]/oauth-metadata.ts
@@ -8,7 +8,7 @@ const hostname =
     : "https://leaflet.pub";
 
 const scope =
-  "atproto transition:email include:pub.leaflet.authFullPermissions include:site.standard.authFull include:app.bsky.authCreatePosts include:app.bsky.authViewAll?aud=did:web:api.bsky.app%23bsky_appview rpc:parts.page.mention.search?aud=* blob:*/*";
+  "atproto account:email?action=read include:pub.leaflet.authFullPermissions include:site.standard.authFull include:app.bsky.authCreatePosts include:app.bsky.authViewAll?aud=did:web:api.bsky.app%23bsky_appview rpc:parts.page.mention.search?aud=* blob:*/*";
 const localconfig: OAuthClientMetadataInput = {
   client_id: `http://localhost/?redirect_uri=${encodeURI(`http://127.0.0.1:3000/api/oauth/callback`)}&scope=${encodeURIComponent(scope)}`,
   client_name: `Leaflet`,

--- a/app/api/oauth/[route]/route.ts
+++ b/app/api/oauth/[route]/route.ts
@@ -44,7 +44,7 @@ export async function GET(
 
       const url = await client.authorize(handle || "https://bsky.social", {
         scope:
-          "atproto transition:email include:pub.leaflet.authFullPermissions include:site.standard.authFull include:app.bsky.authCreatePosts include:app.bsky.authViewAll?aud=did:web:api.bsky.app%23bsky_appview rpc:parts.page.mention.search?aud=* blob:*/*",
+          "atproto account:email?action=read include:pub.leaflet.authFullPermissions include:site.standard.authFull include:app.bsky.authCreatePosts include:app.bsky.authViewAll?aud=did:web:api.bsky.app%23bsky_appview rpc:parts.page.mention.search?aud=* blob:*/*",
         signal: ac.signal,
         state: JSON.stringify(state),
         ...(signup ? { prompt: "create" } : {}),


### PR DESCRIPTION
This PR migrates the `transition:email` scope to `account:email?action=read`, dropping the transitional permission scope.

This should fix issues like #272 for Tranquil PDS users, but also moves email address access to atproto's more fleshed out OAuth permissions system.