### PR TITLE
Security: Missing Authorization Check on Publication Analytics

### DIFF
--- a/app/api/rpc/[command]/get_publication_analytics.ts
+++ b/app/api/rpc/[command]/get_publication_analytics.ts
@@ -41,6 +41,10 @@ export const get_publication_analytics = makeRoute({
       return { error: "not_found" as const };
     }
 
+    if (publication.identity_did !== identity.atp_did) {
+      return { error: "unauthorized" as const };
+    }
+
     const domains = (publication.publication_domains ?? [])
       .map((d) => d.domain)
       .filter(Boolean)


### PR DESCRIPTION
## Summary

Security: Missing Authorization Check on Publication Analytics

## Problem

**Severity**: `High` | **File**: `app/api/rpc/[command]/get_publication_analytics.ts:L28`

In get_publication_analytics.ts, the code checks if the user has entitlements but does not verify that the user actually owns or has access to the specific publication_uri being queried. Any entitled user could potentially access analytics for any publication.

## Solution

Add explicit ownership verification: after fetching the publication, verify that publication.identity_did matches the user's atp_did before returning analytics data.

## Changes

- `app/api/rpc/[command]/get_publication_analytics.ts` (modified)