### PR TITLE
Fix arrow key navigation with footnotes and stored marks

### DIFF
--- a/components/Blocks/TextBlock/keymap.ts
+++ b/components/Blocks/TextBlock/keymap.ts
@@ -112,26 +112,10 @@ export const TextBlockKeymap = (
     "Ctrl-j": moveCursorDown(propsRef, repRef, true),
     ArrowDown: moveCursorDown(propsRef, repRef),
     ArrowLeft: (state, dispatch, view) => {
-      if (state.selection.content().size > 0) return false;
-      let nodeBefore = state.selection.$from.nodeBefore;
-      if (nodeBefore?.type === schema.nodes.footnote) {
-        if (dispatch)
-          dispatch(
-            state.tr.setSelection(
-              TextSelection.create(
-                state.doc,
-                state.selection.from - nodeBefore.nodeSize,
-              ),
-            ),
-          );
-        return true;
-      }
+      if (!state.selection.empty) return false;
+      if (skipFootnote(state, dispatch, "before")) return true;
       if (state.selection.anchor > 1) return false;
-      let marks = state.storedMarks ?? state.selection.$from.marks();
-      if (marks.length > 0) {
-        if (dispatch) dispatch(state.tr.setStoredMarks([]));
-        return true;
-      }
+      if (clearStoredMarks(state, dispatch)) return true;
       let block = propsRef.current.previousBlock;
       if (block) {
         view?.dom.blur();
@@ -140,26 +124,10 @@ export const TextBlockKeymap = (
       return true;
     },
     ArrowRight: (state, dispatch, view) => {
-      if (state.selection.content().size > 0) return false;
-      let nodeAfter = state.selection.$from.nodeAfter;
-      if (nodeAfter?.type === schema.nodes.footnote) {
-        if (dispatch)
-          dispatch(
-            state.tr.setSelection(
-              TextSelection.create(
-                state.doc,
-                state.selection.from + nodeAfter.nodeSize,
-              ),
-            ),
-          );
-        return true;
-      }
+      if (!state.selection.empty) return false;
+      if (skipFootnote(state, dispatch, "after")) return true;
       if (state.doc.content.size - state.selection.anchor > 1) return false;
-      let marks = state.storedMarks ?? state.selection.$from.marks();
-      if (marks.length > 0) {
-        if (dispatch) dispatch(state.tr.setStoredMarks([]));
-        return true;
-      }
+      if (clearStoredMarks(state, dispatch)) return true;
       let block = propsRef.current.nextBlock;
       if (block) {
         view?.dom.blur();
@@ -188,6 +156,36 @@ export const TextBlockKeymap = (
     "Ctrl-Enter": CtrlEnter(propsRef, repRef),
     "Meta-Enter": CtrlEnter(propsRef, repRef),
   }) as { [key: string]: Command };
+
+const skipFootnote = (
+  state: EditorState,
+  dispatch: ((tr: Transaction) => void) | undefined,
+  side: "before" | "after",
+) => {
+  let node =
+    side === "before"
+      ? state.selection.$from.nodeBefore
+      : state.selection.$from.nodeAfter;
+  if (node?.type !== schema.nodes.footnote) return false;
+  let delta = side === "before" ? -node.nodeSize : node.nodeSize;
+  if (dispatch)
+    dispatch(
+      state.tr.setSelection(
+        TextSelection.create(state.doc, state.selection.from + delta),
+      ),
+    );
+  return true;
+};
+
+const clearStoredMarks = (
+  state: EditorState,
+  dispatch: ((tr: Transaction) => void) | undefined,
+) => {
+  let marks = state.storedMarks ?? state.selection.$from.marks();
+  if (marks.length === 0) return false;
+  if (dispatch) dispatch(state.tr.setStoredMarks([]));
+  return true;
+};
 
 const moveCursorDown =
   (

--- a/components/Blocks/TextBlock/keymap.ts
+++ b/components/Blocks/TextBlock/keymap.ts
@@ -111,9 +111,14 @@ export const TextBlockKeymap = (
     ArrowUp: moveCursorUp(propsRef, repRef),
     "Ctrl-j": moveCursorDown(propsRef, repRef, true),
     ArrowDown: moveCursorDown(propsRef, repRef),
-    ArrowLeft: (state, tr, view) => {
+    ArrowLeft: (state, dispatch, view) => {
       if (state.selection.content().size > 0) return false;
       if (state.selection.anchor > 1) return false;
+      let marks = state.storedMarks ?? state.selection.$from.marks();
+      if (marks.length > 0) {
+        if (dispatch) dispatch(state.tr.setStoredMarks([]));
+        return true;
+      }
       let block = propsRef.current.previousBlock;
       if (block) {
         view?.dom.blur();
@@ -121,9 +126,14 @@ export const TextBlockKeymap = (
       }
       return true;
     },
-    ArrowRight: (state, tr, view) => {
+    ArrowRight: (state, dispatch, view) => {
       if (state.selection.content().size > 0) return false;
       if (state.doc.content.size - state.selection.anchor > 1) return false;
+      let marks = state.storedMarks ?? state.selection.$from.marks();
+      if (marks.length > 0) {
+        if (dispatch) dispatch(state.tr.setStoredMarks([]));
+        return true;
+      }
       let block = propsRef.current.nextBlock;
       if (block) {
         view?.dom.blur();

--- a/components/Blocks/TextBlock/keymap.ts
+++ b/components/Blocks/TextBlock/keymap.ts
@@ -113,6 +113,19 @@ export const TextBlockKeymap = (
     ArrowDown: moveCursorDown(propsRef, repRef),
     ArrowLeft: (state, dispatch, view) => {
       if (state.selection.content().size > 0) return false;
+      let nodeBefore = state.selection.$from.nodeBefore;
+      if (nodeBefore?.type === schema.nodes.footnote) {
+        if (dispatch)
+          dispatch(
+            state.tr.setSelection(
+              TextSelection.create(
+                state.doc,
+                state.selection.from - nodeBefore.nodeSize,
+              ),
+            ),
+          );
+        return true;
+      }
       if (state.selection.anchor > 1) return false;
       let marks = state.storedMarks ?? state.selection.$from.marks();
       if (marks.length > 0) {
@@ -128,6 +141,19 @@ export const TextBlockKeymap = (
     },
     ArrowRight: (state, dispatch, view) => {
       if (state.selection.content().size > 0) return false;
+      let nodeAfter = state.selection.$from.nodeAfter;
+      if (nodeAfter?.type === schema.nodes.footnote) {
+        if (dispatch)
+          dispatch(
+            state.tr.setSelection(
+              TextSelection.create(
+                state.doc,
+                state.selection.from + nodeAfter.nodeSize,
+              ),
+            ),
+          );
+        return true;
+      }
       if (state.doc.content.size - state.selection.anchor > 1) return false;
       let marks = state.storedMarks ?? state.selection.$from.marks();
       if (marks.length > 0) {


### PR DESCRIPTION
## Description

Improves arrow key navigation in the TextBlock editor by:

1. **Footnote handling**: Added `skipFootnote()` helper to properly skip over footnote nodes when navigating left/right with arrow keys. When the cursor is adjacent to a footnote, pressing the arrow key will jump over it rather than getting stuck.

2. **Stored marks cleanup**: Added `clearStoredMarks()` helper to clear any stored marks when navigating away from a block. This prevents formatting marks from persisting unexpectedly when moving to adjacent blocks.

3. **Code quality**: 
   - Changed parameter name from `tr` to `dispatch` for clarity (matches ProseMirror Command signature)
   - Replaced `state.selection.content().size > 0` with `!state.selection.empty` for better readability

## Changes

- Modified `ArrowLeft` and `ArrowRight` handlers to use the new helper functions
- Added `skipFootnote()` function to handle cursor movement around footnote nodes
- Added `clearStoredMarks()` function to reset stored marks on block navigation

## Testing

- Verify arrow key navigation works correctly when cursor is adjacent to footnotes
- Verify text formatting doesn't unexpectedly carry over when navigating between blocks
- Test on both mobile and desktop
- Verify undo/redo behavior is correct
- Confirm no build errors

https://claude.ai/code/session_01KX2Tpep5imXoEuWoQBnWNN