### PR TITLE
fix: use resize=contain in supabase image loader to prevent large image cropping

### DIFF
--- a/supabase/supabase-image-loader.js
+++ b/supabase/supabase-image-loader.js
@@ -1,4 +1,8 @@
 export default function supabaseLoader({ src, width, quality }) {
   const path = src.startsWith("/") ? src.slice(1) : src;
-  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/render/image/public/${path}?width=${width}&quality=${quality || 75}`;
+  // resize=contain scales proportionally to fit `width`. Without it Supabase
+  // defaults to resize=cover, and since next/image only passes width (no
+  // height), imgproxy fills the missing height with the source height and crops
+  // the width to fit — chopping the right side off large images. See #286.
+  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/render/image/public/${path}?width=${width}&quality=${quality || 75}&resize=contain`;
 }


### PR DESCRIPTION
Fixes #286

## Problem

Large images were getting their right side cropped — but **only in the published/served view**, not on paste/local preview. That narrows it down: the crop happens in the image *serving* path, not at upload.

Published images render via `next/image`, which routes through our custom loader in [`supabase/supabase-image-loader.js`](https://github.com/hyperlink-academy/leaflet/blob/main/supabase/supabase-image-loader.js). That loader hits Supabase's `render/image` (imgproxy) transform endpoint with only `width` + `quality` and **no `resize` param**, so it defaults to **`resize=cover`**.

`cover` is meant to crop projecting parts to fill a target box. But `next/image` only ever passes `width` to a custom loader — [it never passes `height`](https://nextjs.org/docs/app/api-reference/components/image#loader). With no height, imgproxy fills the missing dimension with the **source** height and then crops the width down to fit its max-dimension box — chopping the right side off.

### Verified against the reported image (5712×4284, from #286)

Hitting the live render endpoint directly:

| Request | Result | Aspect | |
|---|---|---|---|
| `width=3840` (what we send today) | 3000×4284 | portrait | ❌ cropped |
| `width=2500` | 2500×4284 | portrait | ❌ still cropped — clamping width alone does **not** help |
| `width=3840&resize=contain` | 3000×2250 | 1.333 | ✅ correct |
| `width=2500&resize=contain` | 2500×1875 | 1.333 | ✅ correct |

This also explains earlier confusion in the thread: it reproduces on plain desktop Chrome (no browser canvas limit involved) and persisted after the first attempted fix, because that fix touched the upload canvas, not the transform.

## Fix

Add `&resize=contain` to the loader URL so the transform scales proportionally to fit `width` instead of cropping.

```js
.../render/image/public/${path}?width=${width}&quality=${quality || 75}&resize=contain
```

Also reverts the earlier 4096px upload-canvas cap (`normalizeOrientation` in `addImage.ts`), which addressed the wrong layer and did not fix the bug.

### References
- Supabase image transformation `resize` modes (`cover` is the default): https://supabase.com/docs/guides/storage/serving/image-transformations#resizing
- imgproxy resizing types (`cover` crops to fill): https://docs.imgproxy.net/usage/processing#resizing-type

## Test

Upload a large photo (e.g. the `IMG_0953.jpeg` from #286, or any 5000+ px image) and open the **published** leaflet in a new tab. The full image should appear with no right-side crop. Hard-refresh to bypass any cached transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
