### PR TITLE
Only send newsletters on document creation, not updates

### DIFF
--- a/app/api/inngest/client.ts
+++ b/app/api/inngest/client.ts
@@ -42,7 +42,11 @@ export const events = {
     schema: staticSchema<{ documentUris?: string[] }>(),
   }),
   appviewSyncDocumentMetadata: eventType("appview/sync-document-metadata", {
-    schema: staticSchema<{ document_uri: string; bsky_post_uri?: string }>(),
+    schema: staticSchema<{
+      document_uri: string;
+      bsky_post_uri?: string;
+      event_type?: "create" | "update";
+    }>(),
   }),
   userWriteRecordsToPds: eventType("user/write-records-to-pds", {
     schema: staticSchema<{

--- a/app/api/inngest/functions/sync_document_metadata.ts
+++ b/app/api/inngest/functions/sync_document_metadata.ts
@@ -20,7 +20,7 @@ export const sync_document_metadata = inngest.createFunction(
     triggers: [events.appviewSyncDocumentMetadata],
   },
   async ({ event, step }) => {
-    const { document_uri, bsky_post_uri } = event.data;
+    const { document_uri, bsky_post_uri, event_type } = event.data;
 
     const did = new AtUri(document_uri).host;
 
@@ -57,55 +57,58 @@ export const sync_document_metadata = inngest.createFunction(
         .select();
     });
 
-    const broadcast = await step.run(
-      "maybe-claim-newsletter-broadcast",
-      async () => {
-        const { data: docInPub } = await supabaseServerClient
-          .from("documents_in_publications")
-          .select("publication")
-          .eq("document", document_uri)
-          .maybeSingle();
-        const publication_uri = docInPub?.publication;
-        if (!publication_uri) return { skipped: "no_publication" as const };
+    // Only fire newsletter broadcasts on first-time document creation. An
+    // update to an existing post must never trigger a send — otherwise editing
+    // an old post after newsletters were enabled would mail subscribers a post
+    // they never signed up for.
+    if (event_type === "create") {
+      const broadcast = await step.run(
+        "maybe-claim-newsletter-broadcast",
+        async () => {
+          const { data: docInPub } = await supabaseServerClient
+            .from("documents_in_publications")
+            .select("publication")
+            .eq("document", document_uri)
+            .maybeSingle();
+          const publication_uri = docInPub?.publication;
+          if (!publication_uri) return { skipped: "no_publication" as const };
 
-        const { data: settings } = await supabaseServerClient
-          .from("publication_newsletter_settings")
-          .select("enabled")
-          .eq("publication", publication_uri)
-          .maybeSingle();
-        if (!settings?.enabled) {
-          return { skipped: "newsletter_not_enabled" as const };
-        }
+          const { data: settings } = await supabaseServerClient
+            .from("publication_newsletter_settings")
+            .select("enabled")
+            .eq("publication", publication_uri)
+            .maybeSingle();
+          if (!settings?.enabled) {
+            return { skipped: "newsletter_not_enabled" as const };
+          }
 
-        // Composite PK on (publication, document) is the idempotency guard:
-        // re-runs on document updates and races with publishToPublication
-        // both no-op here.
-        const { data: inserted } = await supabaseServerClient
-          .from("publication_post_sends")
-          .upsert(
-            {
-              publication: publication_uri,
-              document: document_uri,
-              status: "pending",
-            },
-            { onConflict: "publication,document", ignoreDuplicates: true },
-          )
-          .select();
-        if (!inserted || inserted.length === 0) {
-          return { skipped: "already_sent_or_pending" as const };
-        }
-        return { claimed: true as const, publication_uri };
-      },
-    );
-
-    if ("claimed" in broadcast) {
-      await step.sendEvent("send-newsletter-broadcast", {
-        name: "newsletter/post.send.requested",
-        data: {
-          publication_uri: broadcast.publication_uri,
-          document_uri,
+          const { data: inserted } = await supabaseServerClient
+            .from("publication_post_sends")
+            .upsert(
+              {
+                publication: publication_uri,
+                document: document_uri,
+                status: "pending",
+              },
+              { onConflict: "publication,document", ignoreDuplicates: true },
+            )
+            .select();
+          if (!inserted || inserted.length === 0) {
+            return { skipped: "already_sent_or_pending" as const };
+          }
+          return { claimed: true as const, publication_uri };
         },
-      });
+      );
+
+      if ("claimed" in broadcast) {
+        await step.sendEvent("send-newsletter-broadcast", {
+          name: "newsletter/post.send.requested",
+          data: {
+            publication_uri: broadcast.publication_uri,
+            document_uri,
+          },
+        });
+      }
     }
 
     if (!bsky_post_uri) {

--- a/appview/index.ts
+++ b/appview/index.ts
@@ -118,6 +118,7 @@ async function handleEvent(evt: Event) {
         data: {
           document_uri: evt.uri.toString(),
           bsky_post_uri: record.value.postRef?.uri,
+          event_type: evt.event,
         },
       });
       if (record.value.publication) {
@@ -285,6 +286,7 @@ async function handleEvent(evt: Event) {
         data: {
           document_uri: evt.uri.toString(),
           bsky_post_uri: record.value.bskyPostRef?.uri,
+          event_type: evt.event,
         },
       });
 


### PR DESCRIPTION
## Description

Prevents newsletter broadcasts from being triggered when existing documents are updated. Previously, the `sync_document_metadata` function would send newsletters for any document sync event, including updates to old posts. This could cause subscribers to receive emails for posts they never signed up for if a post was edited after newsletters were enabled.

## Changes

- Added `event_type` field to the `appviewSyncDocumentMetadata` event schema to distinguish between "create" and "update" events
- Updated `sync_document_metadata` Inngest function to only trigger newsletter broadcasts when `event_type === "create"`
- Wrapped the newsletter broadcast logic in a conditional check
- Updated appview event handlers to pass the event type (`evt.event`) when firing sync events

## Why

The composite primary key on `(publication, document)` in `publication_post_sends` provides idempotency for re-runs and races, but doesn't prevent the initial send from being triggered on document updates. By gating the entire newsletter flow on creation events only, we ensure newsletters are only sent for new posts, not edits to existing ones.

## Testing

Existing Inngest function logic remains unchanged for create events. Update events will now skip the newsletter broadcast step entirely. The change is backward compatible since the `event_type` field is optional in the schema.

https://claude.ai/code/session_01JBGtQm7bgit4hxRYppx6Ya