### PR TITLE
fix footer link colors on about page

### DIFF
--- a/app/about/about.css
+++ b/app/about/about.css
@@ -65,3 +65,7 @@
 
 .aboutSpotlightFeatures {
 }
+
+.aboutFooter a {
+  @apply text-white hover:underline;
+}


### PR DESCRIPTION
Default browser link blue clashed with the green footer background; force
white with a hover underline via the existing .aboutFooter scope.