### PR TITLE
Open profile mentions in new tab on Bluesky

### DIFF
--- a/app/(app)/(home-pages)/p/[didOrHandle]/ProfileHeader.tsx
+++ b/app/(app)/(home-pages)/p/[didOrHandle]/ProfileHeader.tsx
@@ -182,7 +182,7 @@ function parseDescription(description: string): ReactNode[] {
       start: mention.start,
       end: mention.end,
       value: mention.value,
-      href: `/p/${mention.value.slice(1)}`,
+      href: `https://bsky.app/profile/${mention.value.slice(1)}`,
       type: "mention" as const,
     })),
   ].sort((a, b) => a.start - b.start);
@@ -199,9 +199,14 @@ function parseDescription(description: string): ReactNode[] {
 
     if (match.type === "mention") {
       parts.push(
-        <SpeedyLink key={key++} href={match.href}>
+        <a
+          key={key++}
+          href={match.href}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           {match.value}
-        </SpeedyLink>,
+        </a>,
       );
     } else {
       // It's a URL


### PR DESCRIPTION
## Description

Changes profile mention links in user descriptions to open on Bluesky (bsky.app) in a new tab instead of navigating within the app.

### Changes

- Updated mention link href from relative path (`/p/{handle}`) to absolute Bluesky URL (`https://bsky.app/profile/{handle}`)
- Replaced `SpeedyLink` component with standard `<a>` tag to support `target="_blank"` and `rel="noopener noreferrer"` attributes
- This ensures mentions link to the canonical Bluesky profile rather than the local profile view

### Before you pull, have you made sure...

- [x] it looks good on both mobile and desktop
- [x] it undo's like it ought to
- [x] it handles keyboard interactions reasonably well
- [x] no build errors!!!

### Test Plan

Verify that clicking a mention in a profile description opens the user's Bluesky profile in a new tab.

https://claude.ai/code/session_011cFtBC15k9BrvcWt2ymXWf