### PR TITLE
Send subscription confirmation email when subscribing via email login

### DIFF
--- a/actions/emailAuth.tsx
+++ b/actions/emailAuth.tsx
@@ -11,8 +11,18 @@ import { applyAfterSignInAction } from "src/emailSubscription";
 import { pool } from "supabase/pool";
 import { supabaseServerClient } from "supabase/serverClient";
 import { LeafletConfirmEmail } from "emails/leafletConfirmEmail";
+import { PubConfirmEmail } from "emails/pubConfirmEmail";
 import { sendConfirmationEmail } from "src/utils/confirmationEmail";
 import { linkOrphanedEmailSubscribers } from "src/utils/linkOrphanedEmailSubscribers";
+
+// When the email-login flow is entered as part of subscribing to a publication
+// (the embedded subscribe form and the in-app subscribe button both route
+// through it), the confirmation code is sent with a subscription-specific email
+// instead of the generic "sign in" one.
+export type AuthEmailSubscription = {
+  publicationName?: string;
+  publicationUrl?: string;
+};
 
 async function sendAuthCode(email: string, code: string) {
   await sendConfirmationEmail({
@@ -32,6 +42,28 @@ async function sendAuthCode(email: string, code: string) {
   });
 }
 
+async function sendSubscriptionAuthCode(
+  email: string,
+  code: string,
+  subscription: AuthEmailSubscription,
+) {
+  await sendConfirmationEmail({
+    to: email,
+    subject: `Your subscription code is ${code}`,
+    template: (
+      <PubConfirmEmail
+        code={code}
+        publicationName={subscription.publicationName}
+        publicationUrl={subscription.publicationUrl}
+        assetsBaseUrl={process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub"}
+      />
+    ),
+    text: `Paste this code to confirm your subscription:\n\n${code}\n`,
+    devLogTag: "subscriber",
+    code,
+  });
+}
+
 // Throttle window for sending auth codes to a given email. Exposed via an
 // unauthenticated GET endpoint (see app/api/auth/email-login), so without this a
 // crafted link could spam a victim's inbox. Within the window we hand back the
@@ -39,7 +71,10 @@ async function sendAuthCode(email: string, code: string) {
 // the code from the first email still works.
 const AUTH_CODE_THROTTLE_MS = 60 * 1000;
 
-export async function requestAuthEmailToken(emailNonNormalized: string) {
+export async function requestAuthEmailToken(
+  emailNonNormalized: string,
+  subscription?: AuthEmailSubscription,
+) {
   let email = emailNonNormalized.toLowerCase();
   const client = await pool.connect();
   const db = drizzle(client);
@@ -73,7 +108,11 @@ export async function requestAuthEmailToken(emailNonNormalized: string) {
         id: email_auth_tokens.id,
       });
 
-    await sendAuthCode(email, code);
+    if (subscription) {
+      await sendSubscriptionAuthCode(email, code, subscription);
+    } else {
+      await sendAuthCode(email, code);
+    }
 
     return token.id;
   } finally {

--- a/app/api/auth/email-login/route.ts
+++ b/app/api/auth/email-login/route.ts
@@ -6,6 +6,8 @@ import { postAuthRedirect } from "src/postAuthRedirect";
 import { publicationUriForHost } from "src/utils/publicationForHost";
 import { applyAfterSignInAction } from "src/emailSubscription";
 import { parseActionFromSearchParam } from "app/api/oauth/[route]/afterSignInActions";
+import { supabaseServerClient } from "supabase/serverClient";
+import { normalizePublicationRecord } from "src/utils/normalizeRecords";
 
 // Custom-domain email login bounces here first. If the user already has a
 // session on the main site for this same email we hand it straight back to the
@@ -43,15 +45,36 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  let tokenId = await requestAuthEmailToken(email);
+  // A `subscribe` action means the user is subscribing, not just signing in —
+  // send the subscription confirmation email (publication name/url) instead of
+  // the generic auth code.
+  let subscribePublication = parseActionFromSearchParam(action)?.publication;
+  let subscription = subscribePublication
+    ? await resolveSubscriptionEmailContext(subscribePublication)
+    : undefined;
+
+  let tokenId = await requestAuthEmailToken(email, subscription);
   let confirmUrl = new URL("/login/confirm", req.nextUrl.origin);
   confirmUrl.searchParams.set("token", tokenId);
   confirmUrl.searchParams.set("email", email);
   confirmUrl.searchParams.set("redirect", redirect);
   if (action) confirmUrl.searchParams.set("action", action);
   let publicationUri =
-    parseActionFromSearchParam(action)?.publication ||
+    subscribePublication ||
     (await publicationUriForHost(new URL(redirect).host));
   if (publicationUri) confirmUrl.searchParams.set("publication", publicationUri);
   return NextResponse.redirect(confirmUrl.toString());
+}
+
+async function resolveSubscriptionEmailContext(publicationUri: string) {
+  const { data: publication } = await supabaseServerClient
+    .from("publications")
+    .select("record")
+    .eq("uri", publicationUri)
+    .maybeSingle();
+  const normalized = normalizePublicationRecord(publication?.record);
+  return {
+    publicationName: normalized?.name,
+    publicationUrl: normalized?.url,
+  };
 }


### PR DESCRIPTION
## What

When a logged-out user subscribes via email, the unified email-login flow sent the generic **"Sign in to Leaflet"** code email for everyone — including people subscribing through the embedded subscribe form or the in-app subscribe button. This sends the subscription-specific confirmation email instead.

This is a follow-up to #323, which routed the embedded subscribe form through the main-site email-login flow.

## Why

Before the email-login unification, the in-app subscribe flow (`requestPublicationEmailSubscription`) sent a `PubConfirmEmail` — *"Thank you for subscribing to [publication]"*, subject *"Your subscription code is …"*. Once logged-out subscribes were routed through `/api/auth/email-login` → `requestAuthEmailToken`, they all received the generic auth code instead, which reads as a sign-in rather than a subscription confirmation.

## How

- **`actions/emailAuth.tsx`**: added a `sendSubscriptionAuthCode` helper that renders `PubConfirmEmail` (publication name/url), and gave `requestAuthEmailToken` an optional `subscription` context — when present it sends the subscription email, otherwise the generic auth code (unchanged for plain logins).
- **`app/api/auth/email-login/route.ts`**: when the after-sign-in action is `subscribe`, look up the publication's normalized record and pass its name/url so the subscription email is sent. Reused the parsed publication value for the existing `publicationUri` computation.

Both the embedded form (`/api/subscribe_email` → `/api/auth/email-login`) and the in-app subscribe button (`redirectToEmailSubscribe`) hit this route with the `subscribe` action, so both are covered. Pure email logins (no `subscribe` action, e.g. `LoginButton`) still get the generic auth code, and the reused-session fast path sends no email as before.

## Notes
- Backend/email-template change only — no UI surface affected.
- `tsc` is clean for the changed files (remaining output is pre-existing config/env noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5woj51a56sHu8bCa51wKx

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5woj51a56sHu8bCa51wKx)_