### PR TITLE
Use publication icon in subscription confirmation email

### DIFF
--- a/actions/emailAuth.tsx
+++ b/actions/emailAuth.tsx
@@ -22,6 +22,7 @@ import { linkOrphanedEmailSubscribers } from "src/utils/linkOrphanedEmailSubscri
 export type AuthEmailSubscription = {
   publicationName?: string;
   publicationUrl?: string;
+  publicationIcon?: string;
 };
 
 async function sendAuthCode(email: string, code: string) {
@@ -55,6 +56,7 @@ async function sendSubscriptionAuthCode(
         code={code}
         publicationName={subscription.publicationName}
         publicationUrl={subscription.publicationUrl}
+        publicationIcon={subscription.publicationIcon}
         assetsBaseUrl={process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub"}
       />
     ),

--- a/actions/publications/subscribeEmail.tsx
+++ b/actions/publications/subscribeEmail.tsx
@@ -24,6 +24,8 @@ import {
 import type { OAuthSessionError } from "src/atproto-oauth";
 import { normalizePublicationRecord } from "src/utils/normalizeRecords";
 import { linkOrphanedEmailSubscribers } from "src/utils/linkOrphanedEmailSubscribers";
+import { blobRefToSrc } from "src/utils/blobRefToSrc";
+import { AtUri } from "@atproto/api";
 
 type RequestError =
   | "invalid_email"
@@ -63,6 +65,14 @@ export async function requestPublicationEmailSubscription(
   const normalizedPub = normalizePublicationRecord(publication?.record);
   const pubName = normalizedPub?.name;
   const pubUrl = normalizedPub?.url;
+  const assetsBaseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
+  const pubIcon = normalizedPub?.icon
+    ? blobRefToSrc(
+        normalizedPub.icon.ref,
+        new AtUri(publicationUri).host,
+        assetsBaseUrl,
+      )
+    : undefined;
 
   // Fast path: already authenticated with this email — skip the code round-trip.
   if (identity && identity.email?.toLowerCase() === email) {
@@ -132,7 +142,8 @@ export async function requestPublicationEmailSubscription(
         code={pendingCode}
         publicationName={pubName}
         publicationUrl={pubUrl}
-        assetsBaseUrl={process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub"}
+        publicationIcon={pubIcon}
+        assetsBaseUrl={assetsBaseUrl}
       />
     ),
     text: `Paste this code to confirm your subscription:\n\n${pendingCode}\n`,

--- a/app/api/auth/email-login/route.ts
+++ b/app/api/auth/email-login/route.ts
@@ -8,6 +8,8 @@ import { applyAfterSignInAction } from "src/emailSubscription";
 import { parseActionFromSearchParam } from "app/api/oauth/[route]/afterSignInActions";
 import { supabaseServerClient } from "supabase/serverClient";
 import { normalizePublicationRecord } from "src/utils/normalizeRecords";
+import { blobRefToSrc } from "src/utils/blobRefToSrc";
+import { AtUri } from "@atproto/api";
 
 // Custom-domain email login bounces here first. If the user already has a
 // session on the main site for this same email we hand it straight back to the
@@ -73,8 +75,16 @@ async function resolveSubscriptionEmailContext(publicationUri: string) {
     .eq("uri", publicationUri)
     .maybeSingle();
   const normalized = normalizePublicationRecord(publication?.record);
+  const assetsBaseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
   return {
     publicationName: normalized?.name,
     publicationUrl: normalized?.url,
+    publicationIcon: normalized?.icon
+      ? blobRefToSrc(
+          normalized.icon.ref,
+          new AtUri(publicationUri).host,
+          assetsBaseUrl,
+        )
+      : undefined,
   };
 }

--- a/emails/pubConfirmEmail.tsx
+++ b/emails/pubConfirmEmail.tsx
@@ -21,6 +21,7 @@ export const PubConfirmEmail = (props: {
   assetsBaseUrl?: string;
   publicationName?: string;
   publicationUrl?: string;
+  publicationIcon?: string;
 }) => {
   const staticUrl = makeStaticUrl(
     props.assetsBaseUrl ?? "https://leaflet.pub",
@@ -44,7 +45,7 @@ export const PubConfirmEmail = (props: {
                 <Img
                   width={24}
                   height={24}
-                  src={staticUrl("leaflet.png")}
+                  src={props.publicationIcon ?? staticUrl("leaflet.png")}
                   className="rounded-full"
                 />
               </Column>


### PR DESCRIPTION
The publication-themed subscription confirmation email showed the generic
Leaflet logo next to the publication name. Pass the publication's icon
through both email-send paths (direct email subscribe and email-login
subscribe) and render it when available, falling back to the Leaflet logo.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Zrs6KKtu6VkFc2pb1vwjE