### PR TITLE
Stop the firehose broadcast path from emailing opted-out posts

### DIFF
--- a/actions/publishToPublication.ts
+++ b/actions/publishToPublication.ts
@@ -415,10 +415,13 @@ export async function publishToPublication({
     );
   }
 
-  // Fire newsletter broadcast on first publish to a newsletter-enabled pub.
+  // On first publish to a newsletter-enabled pub, claim the post's send slot.
   // The composite PK on publication_post_sends is the real idempotency guard —
-  // ignoreDuplicates makes re-publishes and concurrent runs a no-op.
-  if (publication_uri && !existingDocUri && sendEmail) {
+  // ignoreDuplicates makes re-publishes and concurrent runs a no-op. Claiming
+  // the slot even when not sending (status "skipped") is also what stops the
+  // firehose-driven broadcast in sync_document_metadata from emailing a post the
+  // author opted out of: it finds the row already present and skips.
+  if (publication_uri && !existingDocUri) {
     const { data: settings } = await supabaseServerClient
       .from("publication_newsletter_settings")
       .select("enabled")
@@ -431,12 +434,12 @@ export async function publishToPublication({
           {
             publication: publication_uri,
             document: result.uri,
-            status: "pending",
+            status: sendEmail ? "pending" : "skipped",
           },
           { onConflict: "publication,document", ignoreDuplicates: true },
         )
         .select();
-      if (inserted && inserted.length > 0) {
+      if (sendEmail && inserted && inserted.length > 0) {
         await inngest.send({
           name: "newsletter/post.send.requested",
           data: {

--- a/supabase/migrations/20260630000001_post_sends_skipped_status.sql
+++ b/supabase/migrations/20260630000001_post_sends_skipped_status.sql
@@ -1,0 +1,7 @@
+-- Allow a 'skipped' status on publication_post_sends. publishToPublication
+-- pre-claims the send slot with this status when the author opts out of the
+-- newsletter (e.g. "Post Quietly"), so the firehose-triggered broadcast path in
+-- sync_document_metadata finds the slot already claimed and never sends.
+alter table "public"."publication_post_sends" drop constraint "publication_post_sends_status_check";
+alter table "public"."publication_post_sends" add constraint "publication_post_sends_status_check" CHECK (status IN ('pending','sending','sent','failed','skipped')) not valid;
+alter table "public"."publication_post_sends" validate constraint "publication_post_sends_status_check";


### PR DESCRIPTION
The newsletter email has two independent triggers: the eager path in
publishToPublication (gated by sendEmail) and a firehose-driven path in
sync_document_metadata that claims a broadcast whenever the appview indexes a
newly-created doc in a newsletter-enabled pub. The latter ignored sendEmail
entirely, so a "Post Quietly" publish skipped the eager send but still got
emailed once the record was indexed.

Both paths claim publication_post_sends idempotently (ignoreDuplicates on the
composite PK), so the eager path now always claims the slot on first publish:
status "pending" when sending, "skipped" when the author opted out. The
firehose path then finds the row already present and skips. Adds "skipped" to
the status CHECK constraint; the dashboard renders no badge for it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AMRw9jn6vJwSGaoXEiSWnX