### PR TITLE
Detect Bluesky posts from link metadata, not just hardcoded hosts

### DIFF
--- a/app/api/link_previews/route.ts
+++ b/app/api/link_previews/route.ts
@@ -10,6 +10,7 @@ import {
   getWebpageImage,
 } from "src/utils/getMicroLinkOgImage";
 import { resolveStandardSitePostUrl } from "src/utils/resolveStandardSitePostUrl";
+import { resolveBlueskyPostUrl } from "src/utils/resolveBlueskyPostUrl";
 let supabase = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_API_URL as string,
   process.env.SUPABASE_SERVICE_ROLE_KEY as string,
@@ -20,13 +21,15 @@ export async function POST(req: NextRequest) {
   let body = (await req.json()) as LinkPreviewBody;
   let url = encodeURIComponent(body.url);
   if (body.type === "meta") {
-    let [iframely, leafletPost] = await Promise.all([
+    let [iframely, leafletPost, blueskyPost] = await Promise.all([
       get_link_metadata(url),
       resolveStandardSitePostUrl(body.url, supabase).catch(() => null),
+      resolveBlueskyPostUrl(body.url).catch(() => null),
     ]);
     return Response.json({
       ...iframely,
       leafletPost: leafletPost ? { uri: leafletPost } : null,
+      blueskyPost: blueskyPost ? { uri: blueskyPost } : null,
     });
   } else {
     let result = await get_link_image_preview(body.url);
@@ -37,6 +40,7 @@ export async function POST(req: NextRequest) {
 export type LinkPreviewMetadataResult = Promise<
   Awaited<ReturnType<typeof get_link_metadata>> & {
     leafletPost: { uri: string } | null;
+    blueskyPost: { uri: string } | null;
   }
 >;
 export type LinkPreviewImageResult = ReturnType<typeof get_link_image_preview>;

--- a/src/utils/addLinkBlock.ts
+++ b/src/utils/addLinkBlock.ts
@@ -86,6 +86,21 @@ export async function addLinkBlock(
     return;
   }
 
+  if (data.blueskyPost) {
+    let host = "bsky.app";
+    try {
+      host = new URL(url).host;
+    } catch {}
+    let success = await assertBlueskyPostFacts(
+      data.blueskyPost.uri,
+      host,
+      entityID,
+      rep,
+      ignoreUndo,
+    );
+    if (success) return;
+  }
+
   if (!data.success) {
     await assert([
       {
@@ -210,10 +225,22 @@ export async function addBlueskyPostBlock(
   let postId = urlParts ? urlParts[6] : "";
   let uri = `at://${userDidOrHandle}/${collection}/${postId}`;
 
+  return assertBlueskyPostFacts(uri, host, entityID, rep);
+}
+
+export async function assertBlueskyPostFacts(
+  uri: string,
+  host: string,
+  entityID: string,
+  rep: Replicache<ReplicacheMutators>,
+  ignoreUndo?: boolean,
+) {
   let post = await getBlueskyPost(uri);
   if (!post || post === undefined) return false;
 
-  await rep.mutate.assertFact([
+  let facts: Parameters<typeof rep.mutate.assertFact>[0] & {
+    ignoreUndo?: true;
+  } = [
     {
       entity: entityID,
       attribute: "block/type",
@@ -236,7 +263,9 @@ export async function addBlueskyPostBlock(
         value: host,
       },
     },
-  ]);
+  ];
+  if (ignoreUndo) facts.ignoreUndo = true;
+  await rep.mutate.assertFact(facts);
   return true;
 }
 async function getBlueskyPost(uri: string) {

--- a/src/utils/resolveBlueskyPostUrl.ts
+++ b/src/utils/resolveBlueskyPostUrl.ts
@@ -1,0 +1,84 @@
+import { AtUri } from "@atproto/syntax";
+
+const POST_COLLECTION = "app.bsky.feed.post";
+
+/**
+ * Resolve an arbitrary web URL to a Bluesky post AT URI by reading the page's
+ * link metadata. The bsky.app post template (and its forks) advertise the post
+ * in the document head, either as a raw alternate link to the at:// URI or via
+ * the oembed discovery link whose `url` param is that same URI. Detecting the
+ * tag lets us embed posts from any AT Proto client, not just a hardcoded host
+ * list. Returns null for anything that isn't an app.bsky.feed.post.
+ */
+export async function resolveBlueskyPostUrl(
+  input: string,
+): Promise<string | null> {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+
+  let html: string;
+  try {
+    let res = await fetch(input, {
+      headers: { Accept: "text/html" },
+      next: { revalidate: 60 * 10 },
+    });
+    if (!res.ok) return null;
+    if (!(res.headers.get("content-type") || "").includes("text/html"))
+      return null;
+    html = await res.text();
+  } catch {
+    return null;
+  }
+
+  let uri = extractAtUriFromHead(html);
+  if (!uri) return null;
+
+  try {
+    let parsed = new AtUri(uri);
+    if (parsed.collection !== POST_COLLECTION) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function extractAtUriFromHead(html: string): string | null {
+  let headMatch = html.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i);
+  let scope = headMatch ? headMatch[1] : html;
+  let linkTags = scope.match(/<link\b[^>]*>/gi) || [];
+
+  // Preferred: a direct alternate link to the post's at:// URI.
+  for (let tag of linkTags) {
+    let rel = getAttr(tag, "rel");
+    if (!rel || !/\balternate\b/i.test(rel)) continue;
+    let href = getAttr(tag, "href");
+    if (href?.startsWith("at://")) return href;
+  }
+
+  // Fallback: the oembed discovery link carries the URI in its `url` param.
+  for (let tag of linkTags) {
+    let type = getAttr(tag, "type");
+    if (!type || !/json\+oembed/i.test(type)) continue;
+    let href = getAttr(tag, "href");
+    if (!href) continue;
+    try {
+      let oembedUrl = new URL(href.replace(/&amp;/g, "&"));
+      let target = oembedUrl.searchParams.get("url");
+      if (target?.startsWith("at://")) return target;
+    } catch {}
+  }
+
+  return null;
+}
+
+function getAttr(tag: string, attr: string): string | null {
+  let m =
+    tag.match(new RegExp(`${attr}\\s*=\\s*"([^"]*)"`, "i")) ||
+    tag.match(new RegExp(`${attr}\\s*=\\s*'([^']*)'`, "i"));
+  return m ? m[1] : null;
+}


### PR DESCRIPTION
Bluesky post pages (bsky.app and social-app forks) advertise the post's
at:// URI in their <head> via a `rel="alternate"` link and the oembed
discovery link's `url` param. Read that tag so we can embed posts from any
AT Proto client, instead of only the hardcoded host allowlist.

resolveBlueskyPostUrl runs alongside the existing resolveStandardSitePostUrl
in /api/link_previews, mirroring the leafletPost flow: the route returns a
blueskyPost { uri } and addLinkBlock routes to a bluesky-post block when set.
The hardcoded host list stays as a fast path (no metadata fetch for known
clients). Post fact-writing is factored into assertBlueskyPostFacts so both
the URL fast path and the metadata path share it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KHnp98NJdHeLQXoWxvCW9r