### PR TITLE
Fix tag page timeout by querying indexed document_tags table

### DIFF
--- a/app/(app)/(home-pages)/tag/[tag]/getDocumentsByTag.ts
+++ b/app/(app)/(home-pages)/tag/[tag]/getDocumentsByTag.ts
@@ -15,7 +15,9 @@ import { resolveBylineProfiles } from "src/utils/resolveBylineProfiles";
 export async function getDocumentsByTag(
   tag: string,
 ): Promise<{ posts: Post[] }> {
-  // Query documents that have this tag
+  // Query documents that have this tag via the normalized document_tags table,
+  // which stores lowercased tags and is indexed. Tag links are lowercased (they
+  // come from search_tags), so match against the lowercased tag.
   const { data: rawDocuments, error } = await supabaseServerClient
     .from("documents")
     .select(
@@ -23,9 +25,10 @@ export async function getDocumentsByTag(
       comments_on_documents(count),
       document_mentions_in_bsky(count),
       recommends_on_documents(count),
-      documents_in_publications(publications(*))`,
+      documents_in_publications(publications(*)),
+      document_tags!inner(tag)`,
     )
-    .contains("data->tags", `["${tag}"]`)
+    .eq("document_tags.tag", tag.toLowerCase())
     .order("sort_date", { ascending: false })
     .limit(50);
 

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -326,6 +326,29 @@ export type Database = {
           },
         ]
       }
+      document_tags: {
+        Row: {
+          tag: string
+          uri: string
+        }
+        Insert: {
+          tag: string
+          uri: string
+        }
+        Update: {
+          tag?: string
+          uri?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "document_tags_uri_fkey"
+            columns: ["uri"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["uri"]
+          },
+        ]
+      }
       documents: {
         Row: {
           bsky_like_count: number


### PR DESCRIPTION
The search_tags optimization migration dropped the idx_documents_tags GIN
index on data->'tags', but getDocumentsByTag still used a .contains()
JSONB containment filter against that column. With no supporting index the
query full-scanned the documents table and hit the statement timeout (57014).

Query the normalized, indexed document_tags table via an inner join instead.
This also fixes a latent case-sensitivity bug: tags are stored with their
original case in data->'tags', but tag links are lowercased (they come from
search_tags), so the old case-sensitive containment match missed mixed-case
tags. document_tags stores lowercased tags, and we now match on the
lowercased tag.

Add the document_tags table to the generated Supabase types (the table was
created by the migration but the types were never regenerated).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01723qeHdhQmTTG8mqkDXJ2Q