### PR TITLE
Match publication post URLs against document record paths

### DIFF
--- a/app/(app)/lish/[did]/[publication]/[rkey]/DocumentPageRenderer.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/DocumentPageRenderer.tsx
@@ -29,9 +29,11 @@ import {
 export async function DocumentPageRenderer({
   did,
   rkey,
+  publication,
 }: {
   did: string;
   rkey: string;
+  publication?: string;
 }) {
   let agent = new AtpAgent({
     service: "https://public.api.bsky.app",
@@ -43,7 +45,7 @@ export async function DocumentPageRenderer({
   });
 
   let [document, profile] = await Promise.all([
-    getPostPageData(did, rkey),
+    getPostPageData(did, rkey, publication),
     agent.getProfile({ actor: did }).then(
       (res) => res.data,
       () => undefined,

--- a/app/(app)/lish/[did]/[publication]/[rkey]/getPostPageData.ts
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/getPostPageData.ts
@@ -12,8 +12,16 @@ import {
 } from "lexicons/api";
 import { documentUriFilter } from "src/utils/uriHelpers";
 import { getDocumentURL } from "app/(app)/lish/createPub/getPublicationURL";
+import { resolveDocumentFilter } from "../resolveDocumentFilter";
 
-export async function getPostPageData(did: string, rkey: string) {
+export async function getPostPageData(
+  did: string,
+  rkey: string,
+  publicationName?: string,
+) {
+  let filter = publicationName
+    ? await resolveDocumentFilter(did, publicationName, rkey)
+    : documentUriFilter(did, rkey);
   let { data: documents } = await supabaseServerClient
     .from("documents")
     .select(
@@ -32,7 +40,7 @@ export async function getPostPageData(did: string, rkey: string) {
         recommends_on_documents(count)
         `,
     )
-    .or(documentUriFilter(did, rkey))
+    .or(filter)
     .order("uri", { ascending: false })
     .limit(1);
   let document = documents?.[0];

--- a/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
@@ -3,7 +3,7 @@ import { supabaseServerClient } from "supabase/serverClient";
 import { jsonToLex } from "@atproto/lexicon";
 import { fetchAtprotoBlob } from "app/api/atproto_images/route";
 import { normalizeDocumentRecord } from "src/utils/normalizeRecords";
-import { documentUriFilter } from "src/utils/uriHelpers";
+import { resolveDocumentFilter } from "../resolveDocumentFilter";
 
 export const revalidate = 60;
 
@@ -12,12 +12,14 @@ export default async function OpenGraphImage(props: {
 }) {
   let params = await props.params;
   let did = decodeURIComponent(params.did);
+  let publication = decodeURIComponent(params.publication);
+  let rkey = decodeURIComponent(params.rkey);
 
   // Try to get the document's cover image
   let { data: documents } = await supabaseServerClient
     .from("documents")
     .select("data")
-    .or(documentUriFilter(did, params.rkey))
+    .or(await resolveDocumentFilter(did, publication, rkey))
     .order("uri", { ascending: false })
     .limit(1);
   let document = documents?.[0];

--- a/app/(app)/lish/[did]/[publication]/[rkey]/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/page.tsx
@@ -7,10 +7,8 @@ import {
   normalizeDocumentRecord,
   normalizePublicationRecord,
 } from "src/utils/normalizeRecords";
-import {
-  documentUriFilter,
-  publicationNameOrUriFilter,
-} from "src/utils/uriHelpers";
+import { publicationNameOrUriFilter } from "src/utils/uriHelpers";
+import { resolveDocumentFilter } from "../resolveDocumentFilter";
 import { getDocumentURL } from "app/(app)/lish/createPub/getPublicationURL";
 import { findPublishedPage } from "src/utils/publishedPageMetadata";
 
@@ -43,7 +41,7 @@ export async function generateMetadata(props: {
     supabaseServerClient
       .from("documents")
       .select("*, documents_in_publications(publications(*))")
-      .or(documentUriFilter(did, params.rkey))
+      .or(await resolveDocumentFilter(did, publication_name, rkey))
       .order("uri", { ascending: false })
       .limit(1),
   ]);
@@ -129,5 +127,7 @@ export default async function Post(props: {
     });
     if (pageRender) return pageRender;
   }
-  return <DocumentPageRenderer did={did} rkey={rkey} />;
+  return (
+    <DocumentPageRenderer did={did} rkey={rkey} publication={publication_name} />
+  );
 }

--- a/app/(app)/lish/[did]/[publication]/resolveDocumentFilter.ts
+++ b/app/(app)/lish/[did]/[publication]/resolveDocumentFilter.ts
@@ -1,0 +1,36 @@
+import { supabaseServerClient } from "supabase/serverClient";
+import {
+  documentUriFilter,
+  publicationNameOrUriFilter,
+} from "src/utils/uriHelpers";
+
+/**
+ * Resolves the trailing segment of a publication post URL to a documents
+ * query filter. Documents publish under the `path` in their record — usually
+ * "/<rkey>", but records written by other clients can use any path — so match
+ * the record path within the publication first and fall back to treating the
+ * segment as an rkey.
+ */
+export async function resolveDocumentFilter(
+  did: string,
+  publicationName: string,
+  segment: string,
+): Promise<string> {
+  const path = segment.startsWith("/") ? segment : "/" + segment;
+  const { data } = await supabaseServerClient
+    .from("documents_in_publications")
+    .select(
+      "document, documents!inner(uri), publications!inner(uri, name, identity_did)",
+    )
+    .eq("publications.identity_did", did)
+    .or(publicationNameOrUriFilter(did, publicationName), {
+      referencedTable: "publications",
+    })
+    // Record paths may be stored with or without the leading slash
+    .in("documents.data->>path", [path, path.slice(1)])
+    .order("document", { ascending: false })
+    .limit(1);
+
+  const uri = data?.[0]?.document;
+  return uri ? `uri.eq.${uri}` : documentUriFilter(did, segment);
+}


### PR DESCRIPTION
The /lish/[did]/[publication]/[rkey] segment was only ever treated as a
document rkey, so site.standard documents whose record `path` differs
from "/<rkey>" (e.g. written by other clients) weren't reachable at
their published URL. Resolve the segment against the `path` in document
records within the publication first, falling back to the rkey lookup,
across the page body, metadata, and opengraph image. The standalone /p/
route keeps rkey-only resolution.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tk2dZyRGsUwFNJ8QnH8umH