### PR TITLE
Fix tags write amplification and remaining full-scan queries

### DIFF
--- a/actions/searchTags.ts
+++ b/actions/searchTags.ts
@@ -11,7 +11,12 @@ export async function searchTags(
 ): Promise<TagSearchResult[] | null> {
   const searchQuery = query.trim().toLowerCase();
 
-  // Use raw SQL query to extract and aggregate tags
+  // 1-2 character patterns can't use the trigram index (and the UI only
+  // shows results from 3 characters), so don't hit the database for them.
+  if (searchQuery.length > 0 && searchQuery.length < 3) {
+    return [];
+  }
+
   const { data, error } = await supabaseServerClient.rpc("search_tags", {
     search_query: searchQuery,
   });

--- a/app/(app)/(home-pages)/tag/[tag]/getDocumentsByTag.ts
+++ b/app/(app)/(home-pages)/tag/[tag]/getDocumentsByTag.ts
@@ -15,9 +15,26 @@ import { resolveBylineProfiles } from "src/utils/resolveBylineProfiles";
 export async function getDocumentsByTag(
   tag: string,
 ): Promise<{ posts: Post[] }> {
-  // Query documents that have this tag via the normalized document_tags table,
-  // which stores lowercased tags and is indexed. Tag links are lowercased (they
-  // come from search_tags), so match against the lowercased tag.
+  // Resolve the tag to document uris first via a function whose plan is
+  // pinned to the document_tags tag index. Ordering by sort_date with a limit
+  // while joining in one query lets the planner walk the sort_date index and
+  // probe every document for the tag — a full table scan for rare tags.
+  // document_tags stores lowercased tags (tag links come from search_tags),
+  // so match on the lowercased tag.
+  const { data: tagged, error: tagError } = await supabaseServerClient.rpc(
+    "get_tag_page_document_uris",
+    { tag_query: tag.toLowerCase(), max_count: 50 },
+  );
+
+  if (tagError) {
+    console.error("Error fetching documents by tag:", tagError);
+    return { posts: [] };
+  }
+  const uris = (tagged || []).map((row) => row.uri);
+  if (uris.length === 0) {
+    return { posts: [] };
+  }
+
   const { data: rawDocuments, error } = await supabaseServerClient
     .from("documents")
     .select(
@@ -25,12 +42,10 @@ export async function getDocumentsByTag(
       comments_on_documents(count),
       document_mentions_in_bsky(count),
       recommends_on_documents(count),
-      documents_in_publications(publications(*)),
-      document_tags!inner(tag)`,
+      documents_in_publications(publications(*))`,
     )
-    .eq("document_tags.tag", tag.toLowerCase())
-    .order("sort_date", { ascending: false })
-    .limit(50);
+    .in("uri", uris)
+    .order("sort_date", { ascending: false });
 
   if (error) {
     console.error("Error fetching documents by tag:", error);

--- a/components/Tags.tsx
+++ b/components/Tags.tsx
@@ -91,9 +91,15 @@ const TagSearchInput = (props: {
 
   let inputWidth = placeholderInputRef.current?.clientWidth;
 
-  // Fetch tags whenever the input value changes
+  // Fetch tags whenever the input value changes. Results are only shown from
+  // 3 characters on, so don't issue a search for shorter inputs — notably the
+  // empty string this effect fires with on mount.
   useDebouncedEffect(
     async () => {
+      if (tagInputValue.trim().length < 3) {
+        setSearchResults([]);
+        return;
+      }
       setIsSearching(true);
       const results = await searchTags(tagInputValue);
       if (results) {

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -1819,6 +1819,21 @@ export type Database = {
           },
         ]
       }
+      tag_counts: {
+        Row: {
+          document_count: number
+          tag: string
+        }
+        Insert: {
+          document_count?: number
+          tag: string
+        }
+        Update: {
+          document_count?: number
+          tag?: string
+        }
+        Relationships: []
+      }
       user_entitlements: {
         Row: {
           entitlement_key: string
@@ -2041,6 +2056,15 @@ export type Database = {
           publication_uri: string
           publication_record: Json
           publication_name: string
+        }[]
+      }
+      get_tag_page_document_uris: {
+        Args: {
+          tag_query: string
+          max_count?: number
+        }
+        Returns: {
+          uri: string
         }[]
       }
       parse_iso_timestamp: {

--- a/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
+++ b/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
@@ -159,3 +159,12 @@ $$ LANGUAGE sql STABLE SET enable_seqscan = off;
 REVOKE INSERT, UPDATE, DELETE ON TABLE "public"."document_tags" FROM "anon", "authenticated";
 GRANT SELECT ON TABLE "public"."tag_counts" TO "anon", "authenticated";
 GRANT ALL ON TABLE "public"."tag_counts" TO "service_role";
+
+-- tag_counts was just created and backfilled, so it has no statistics until
+-- autoanalyze runs; document_tags stats predate the trigger churn. Refresh
+-- both so the new plans are chosen from the first query. (VACUUM can't run
+-- here — migrations execute inside a transaction — so reclaiming the bloat
+-- the old trigger left in document_tags stays with autovacuum, or a one-off
+-- manual `VACUUM public.document_tags` to speed it up.)
+ANALYZE "public"."document_tags";
+ANALYZE "public"."tag_counts";

--- a/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
+++ b/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
@@ -1,0 +1,161 @@
+-- The document_tags optimization introduced two regressions and left one scan
+-- unfixed:
+--
+-- 1. Write amplification: the sync trigger fires on EVERY insert/update of
+--    documents.data — the firehose upserts a document's data on every event and
+--    sync_document_metadata rewrites it again — and each firing did a blanket
+--    DELETE + re-INSERT of that document's tag rows even when tags were
+--    unchanged. That churns dead tuples through the table and both of its
+--    indexes (including a GIN trigram index, which is expensive to maintain)
+--    on the hottest write path in the system.
+--
+-- 2. search_tags('') still aggregates the ENTIRE document_tags table
+--    (GROUP BY + COUNT DISTINCT + ORDER BY count) — a full scan that grows
+--    with the corpus, and the trigram index cannot help 1-2 character LIKE
+--    patterns, which also fall back to full scans.
+--
+-- 3. The tag page orders documents by sort_date with a LIMIT while joining
+--    document_tags; the planner can choose to walk documents_sort_date_idx
+--    and probe every document for the tag — a full scan of documents for
+--    rare tags.
+--
+-- Fix: gate the trigger on actual tag changes and sync differentially;
+-- maintain a small tag_counts rollup so tag search never aggregates; move the
+-- trigram index to the rollup; and serve the tag page from a function whose
+-- plan is fenced to start from the tag index.
+
+SET LOCAL search_path = public, extensions;
+
+-- ---------------------------------------------------------------------------
+-- Tag count rollup: one row per distinct tag, maintained by trigger.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "public"."tag_counts" (
+    "tag" text NOT NULL PRIMARY KEY,
+    "document_count" bigint NOT NULL DEFAULT 0
+);
+ALTER TABLE "public"."tag_counts" ENABLE ROW LEVEL SECURITY;
+
+-- Serves the top-tags query (empty search) as a bounded index scan.
+CREATE INDEX IF NOT EXISTS idx_tag_counts_count
+    ON "public"."tag_counts" (document_count DESC, tag ASC);
+-- Substring search now runs against distinct tags instead of every
+-- (document, tag) pair; the trigram index keeps it index-assisted.
+CREATE INDEX IF NOT EXISTS idx_tag_counts_tag_trgm
+    ON "public"."tag_counts" USING gin (tag gin_trgm_ops);
+
+CREATE OR REPLACE FUNCTION sync_tag_counts()
+RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        INSERT INTO "public"."tag_counts" (tag, document_count)
+        VALUES (NEW.tag, 1)
+        ON CONFLICT (tag)
+        DO UPDATE SET document_count = tag_counts.document_count + 1;
+        RETURN NEW;
+    ELSE
+        UPDATE "public"."tag_counts"
+        SET document_count = document_count - 1
+        WHERE tag = OLD.tag;
+        DELETE FROM "public"."tag_counts"
+        WHERE tag = OLD.tag AND document_count <= 0;
+        RETURN OLD;
+    END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Creating the trigger takes an exclusive lock on document_tags, so the
+-- backfill below sees a consistent snapshot: rows written after this
+-- migration commits go through the trigger, rows before it are aggregated.
+DROP TRIGGER IF EXISTS document_tags_sync_counts ON "public"."document_tags";
+CREATE TRIGGER document_tags_sync_counts
+    AFTER INSERT OR DELETE ON "public"."document_tags"
+    FOR EACH ROW EXECUTE FUNCTION sync_tag_counts();
+
+INSERT INTO "public"."tag_counts" (tag, document_count)
+SELECT tag, COUNT(*) FROM "public"."document_tags" GROUP BY tag
+ON CONFLICT (tag) DO UPDATE SET document_count = EXCLUDED.document_count;
+
+-- ---------------------------------------------------------------------------
+-- Differential document_tags sync, gated on tags actually changing.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION sync_document_tags()
+RETURNS trigger AS $$
+BEGIN
+    IF jsonb_typeof(NEW.data->'tags') = 'array' THEN
+        DELETE FROM "public"."document_tags" dt
+        WHERE dt.uri = NEW.uri
+          AND dt.tag NOT IN (
+            SELECT LOWER(t)
+            FROM jsonb_array_elements_text(NEW.data->'tags') AS t
+            WHERE t IS NOT NULL
+          );
+        INSERT INTO "public"."document_tags" (uri, tag)
+        SELECT NEW.uri, LOWER(t)
+        FROM jsonb_array_elements_text(NEW.data->'tags') AS t
+        WHERE t IS NOT NULL
+        ON CONFLICT DO NOTHING;
+    ELSE
+        DELETE FROM "public"."document_tags" WHERE uri = NEW.uri;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Split the old single trigger so updates only fire when the tags array
+-- actually changed; unrelated data updates (blob inflation, postRef writes,
+-- backfill jobs) no longer touch document_tags at all.
+DROP TRIGGER IF EXISTS documents_sync_tags ON "public"."documents";
+DROP TRIGGER IF EXISTS documents_sync_tags_insert ON "public"."documents";
+DROP TRIGGER IF EXISTS documents_sync_tags_update ON "public"."documents";
+CREATE TRIGGER documents_sync_tags_insert
+    AFTER INSERT ON "public"."documents"
+    FOR EACH ROW EXECUTE FUNCTION sync_document_tags();
+CREATE TRIGGER documents_sync_tags_update
+    AFTER UPDATE OF data ON "public"."documents"
+    FOR EACH ROW
+    WHEN (OLD.data->'tags' IS DISTINCT FROM NEW.data->'tags')
+    EXECUTE FUNCTION sync_document_tags();
+
+-- The trigram index on document_tags is no longer queried (search moved to
+-- tag_counts); dropping it removes GIN maintenance from the write path. The
+-- plain B-tree on tag stays for the tag-page equality lookups.
+DROP INDEX IF EXISTS idx_document_tags_tag_trgm;
+
+-- ---------------------------------------------------------------------------
+-- search_tags: same signature, now O(matching distinct tags) with no
+-- aggregation; the empty query is a LIMIT 20 index scan.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION search_tags(search_query text)
+RETURNS TABLE (name text, document_count bigint) AS $$
+    SELECT tc.tag, tc.document_count
+    FROM "public"."tag_counts" tc
+    WHERE search_query = '' OR tc.tag LIKE '%' || search_query || '%'
+    ORDER BY tc.document_count DESC, tc.tag ASC
+    LIMIT 20;
+$$ LANGUAGE sql STABLE;
+
+-- ---------------------------------------------------------------------------
+-- Tag page: return the newest document uris for a tag. The MATERIALIZED CTE
+-- is an optimization fence that forces the plan to start from the
+-- document_tags tag index — the planner can never choose to walk
+-- documents_sort_date_idx probing every document for the tag. enable_seqscan
+-- is scoped to this function so the join runs as pkey probes per tagged
+-- document instead of hashing the whole documents table; every index the
+-- fenced plan needs exists, so nothing here can degrade to a scan.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_tag_page_document_uris(tag_query text, max_count int DEFAULT 50)
+RETURNS TABLE (uri text) AS $$
+    WITH tag_docs AS MATERIALIZED (
+        SELECT dt.uri FROM "public"."document_tags" dt WHERE dt.tag = tag_query
+    )
+    SELECT d.uri
+    FROM "public"."documents" d
+    JOIN tag_docs td ON td.uri = d.uri
+    ORDER BY d.sort_date DESC NULLS LAST
+    LIMIT max_count;
+$$ LANGUAGE sql STABLE SET enable_seqscan = off;
+
+-- Only the SECURITY DEFINER trigger and the service role write these tables.
+REVOKE INSERT, UPDATE, DELETE ON TABLE "public"."document_tags" FROM "anon", "authenticated";
+GRANT SELECT ON TABLE "public"."tag_counts" TO "anon", "authenticated";
+GRANT ALL ON TABLE "public"."tag_counts" TO "service_role";


### PR DESCRIPTION
The document_tags optimization left three problems:

1. Write amplification on ingest: the sync trigger fired on every
   insert/update of documents.data (firehose upserts, blob inflation,
   backfill jobs) and did a blanket DELETE + re-INSERT of the document's
   tag rows even when tags were unchanged, churning dead tuples through
   the table and its GIN trigram index on the hottest write path.
   The trigger is now split: inserts sync as before, updates only fire
   WHEN the tags array actually changed, and the sync is differential
   (delete removed tags, insert added ones).

2. search_tags('') still aggregated the entire document_tags table
   (GROUP BY + COUNT DISTINCT + ORDER BY count) — a full scan that grew
   with the corpus — and fired on every mount of the tag input even
   though the UI never shows results under 3 characters. 1-2 character
   LIKE patterns also can't use the trigram index and fell back to full
   scans. Tag search now reads a small trigger-maintained tag_counts
   rollup (one row per distinct tag): the empty query is a LIMIT 20
   index-only scan and substring search runs over distinct tags with a
   trigram index, no aggregation at all. The client and server action
   skip the database entirely for sub-3-character queries, and the
   now-unused trigram index on document_tags is dropped, removing GIN
   maintenance from the write path.

3. The tag page ordered documents by sort_date with a LIMIT while
   joining document_tags, letting the planner walk the sort_date index
   and probe every document for the tag — a full scan of documents for
   rare tags. The page now resolves uris through
   get_tag_page_document_uris, whose MATERIALIZED CTE fence and
   function-scoped enable_seqscan=off pin the plan to the tag index
   plus pkey probes, bounded by the tag's own documents, then fetches
   the rich rows for at most 50 uris.

Verified against Postgres 16: trigger no-ops on unrelated data updates
and firehose replays (ctids unchanged), differential sync and cascade
deletes keep tag_counts drift at zero, and EXPLAIN confirms index-only
top tags, trigram-indexed search, and an index-bounded tag page plan at
200k documents.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SWzh6uWz3ZZht2nmveFiJG