### PR TITLE
Repair the tags migration deploy: transactional, deadlock-safe, re-runnable

### DIFF
--- a/app/(app)/(home-pages)/tag/[tag]/getDocumentsByTag.ts
+++ b/app/(app)/(home-pages)/tag/[tag]/getDocumentsByTag.ts
@@ -26,11 +26,27 @@ export async function getDocumentsByTag(
     { tag_query: tag.toLowerCase(), max_count: 50 },
   );
 
+  let uris: string[];
   if (tagError) {
-    console.error("Error fetching documents by tag:", tagError);
-    return { posts: [] };
+    // The function ships in a migration that deploys separately from this
+    // code; if it isn't there (yet), degrade to querying document_tags
+    // directly rather than rendering an empty page. The cap keeps the .in()
+    // filter below URL length limits, so a very popular tag may miss some of
+    // its newest posts until the function exists.
+    console.error("Error fetching tag document uris:", tagError);
+    const { data: fallback, error: fallbackError } = await supabaseServerClient
+      .from("document_tags")
+      .select("uri")
+      .eq("tag", tag.toLowerCase())
+      .limit(200);
+    if (fallbackError) {
+      console.error("Error fetching documents by tag:", fallbackError);
+      return { posts: [] };
+    }
+    uris = (fallback || []).map((row) => row.uri);
+  } else {
+    uris = (tagged || []).map((row) => row.uri);
   }
-  const uris = (tagged || []).map((row) => row.uri);
   if (uris.length === 0) {
     return { posts: [] };
   }
@@ -45,7 +61,8 @@ export async function getDocumentsByTag(
       documents_in_publications(publications(*))`,
     )
     .in("uri", uris)
-    .order("sort_date", { ascending: false });
+    .order("sort_date", { ascending: false })
+    .limit(50);
 
   if (error) {
     console.error("Error fetching documents by tag:", error);

--- a/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
+++ b/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
@@ -23,8 +23,25 @@
 -- maintain a small tag_counts rollup so tag search never aggregates; move the
 -- trigram index to the rollup; and serve the tag page from a function whose
 -- plan is fenced to start from the tag index.
+--
+-- The CI supabase CLI applies migration statements in autocommit mode (its
+-- first attempt at this file half-applied and then deadlocked against the
+-- firehose), so the transaction is explicit. Every statement is idempotent
+-- so the file is safe to re-run over the partially applied state.
+BEGIN;
 
 SET LOCAL search_path = public, extensions;
+SET LOCAL lock_timeout = '15s';
+
+-- Take both exclusive locks up front, documents first — the same order the
+-- write path locks them (a documents write fires the sync trigger, which then
+-- writes document_tags). The first attempt locked document_tags first via
+-- CREATE TRIGGER and then requested documents for DROP TRIGGER, forming a
+-- lock-order cycle with an in-flight firehose upsert: deadlock. Acquiring in
+-- write-path order just waits for in-flight writers instead of deadlocking,
+-- and lock_timeout bounds the wait (on timeout everything rolls back and the
+-- deploy can be re-run).
+LOCK TABLE "public"."documents", "public"."document_tags" IN ACCESS EXCLUSIVE MODE;
 
 -- ---------------------------------------------------------------------------
 -- Tag count rollup: one row per distinct tag, maintained by trigger.
@@ -63,9 +80,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
--- Creating the trigger takes an exclusive lock on document_tags, so the
--- backfill below sees a consistent snapshot: rows written after this
--- migration commits go through the trigger, rows before it are aggregated.
+-- The exclusive lock held on document_tags means the backfill below sees a
+-- consistent snapshot: rows written after this migration commits go through
+-- the trigger, rows before it are aggregated.
 DROP TRIGGER IF EXISTS document_tags_sync_counts ON "public"."document_tags";
 CREATE TRIGGER document_tags_sync_counts
     AFTER INSERT OR DELETE ON "public"."document_tags"
@@ -74,6 +91,12 @@ CREATE TRIGGER document_tags_sync_counts
 INSERT INTO "public"."tag_counts" (tag, document_count)
 SELECT tag, COUNT(*) FROM "public"."document_tags" GROUP BY tag
 ON CONFLICT (tag) DO UPDATE SET document_count = EXCLUDED.document_count;
+-- On a re-run the table may hold counts from the earlier partial apply for
+-- tags that have since disappeared; the insert above can't remove those.
+DELETE FROM "public"."tag_counts" tc
+WHERE NOT EXISTS (
+    SELECT 1 FROM "public"."document_tags" dt WHERE dt.tag = tc.tag
+);
 
 -- ---------------------------------------------------------------------------
 -- Differential document_tags sync, gated on tags actually changing.
@@ -168,3 +191,5 @@ GRANT ALL ON TABLE "public"."tag_counts" TO "service_role";
 -- manual `VACUUM public.document_tags` to speed it up.)
 ANALYZE "public"."document_tags";
 ANALYZE "public"."tag_counts";
+
+COMMIT;


### PR DESCRIPTION
## Why /tag/ pages are empty

The Deploy workflow failed on the #334 merge commit ([run 28626116158](https://github.com/hyperlink-academy/leaflet/actions/runs/28626116158)), leaving the `20260702000000` migration **half-applied** in production:

1. The CI Supabase CLI (v2.20.3) applies migration statements in **autocommit mode**, not one transaction (`WARNING: SET LOCAL can only be used in transaction blocks` in the log), so a mid-file failure leaves earlier statements committed.
2. It **deadlocked** at `DROP TRIGGER documents_sync_tags ON documents`: the migration held the exclusive lock on `document_tags` (from creating the counts trigger) while requesting `documents`, while an in-flight firehose upsert held `documents` and waited to write `document_tags` through the old trigger — opposite lock order.

Everything after that statement never ran, including `get_tag_page_document_uris`, so the tag page's RPC call errors and renders zero posts.

## What this changes

- **Explicit `BEGIN`/`COMMIT`** in the migration file (the CLI won't wrap it), with `lock_timeout = '15s'`.
- **Up-front `LOCK TABLE documents, document_tags`** in the same order the write path locks them, so the migration waits for in-flight firehose writers to drain instead of deadlocking. On timeout the whole file rolls back cleanly and the deploy job can simply be re-run.
- **Re-runnable over the current half-applied production state**: all statements are idempotent, and stale `tag_counts` rows left by the partial apply get cleaned up.
- **Tag page degrades gracefully**: if the RPC is missing (code and migrations deploy with skew), `getDocumentsByTag` falls back to querying `document_tags` directly instead of showing an empty page.

Merging this retries the failed migration (it was never recorded in `schema_migrations`); tag pages recover as soon as it applies.

## Verification (checklist)

- it looks good on both mobile and desktop — n/a, no UI changes; the tag page renders the same `PostListing` list once data returns
- it undo's like it ought to — n/a, no editor/mutation changes
- it handles keyboard interactions reasonably well — n/a
- no build errors!!! — `npx tsc` clean; migration tested on Postgres 16 in autocommit mode by reproducing the exact half-applied production state and re-running the repaired file over it: no errors, old blanket trigger replaced by the gated pair, both functions present, zero `tag_counts` drift

Also worth a follow-up: `supabase/setup-cli@v1` installed a year-old CLI (v2.20.3 vs v2.109.0 current); pinning a recent version in the workflow would give transactional migrations upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWzh6uWz3ZZht2nmveFiJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWzh6uWz3ZZht2nmveFiJG)_