### PR TITLE
Fix tags migration statement timeout: rebuild tag_counts wholesale

### DIFF
--- a/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
+++ b/supabase/migrations/20260702000000_fix_tags_write_amplification_and_scans.sql
@@ -32,6 +32,11 @@ BEGIN;
 
 SET LOCAL search_path = public, extensions;
 SET LOCAL lock_timeout = '15s';
+-- The role's default statement timeout (~2min) killed the second deploy
+-- attempt mid-backfill; the tables this scans keep growing, so give the
+-- migration its own generous budget. lock_timeout above still bounds any
+-- lock wait.
+SET LOCAL statement_timeout = '10min';
 
 -- Take both exclusive locks up front, documents first — the same order the
 -- write path locks them (a documents write fires the sync trigger, which then
@@ -88,15 +93,14 @@ CREATE TRIGGER document_tags_sync_counts
     AFTER INSERT OR DELETE ON "public"."document_tags"
     FOR EACH ROW EXECUTE FUNCTION sync_tag_counts();
 
+-- Rebuild the rollup from scratch: a partial earlier apply may have left rows
+-- for tags that no longer exist, and reconciling those with a NOT EXISTS
+-- anti-join timed out in production — probing for a vanished tag crawls the
+-- dead index entries the old churny trigger left behind. Deleting the small
+-- rollup wholesale and re-aggregating does one predictable pass instead.
+DELETE FROM "public"."tag_counts";
 INSERT INTO "public"."tag_counts" (tag, document_count)
-SELECT tag, COUNT(*) FROM "public"."document_tags" GROUP BY tag
-ON CONFLICT (tag) DO UPDATE SET document_count = EXCLUDED.document_count;
--- On a re-run the table may hold counts from the earlier partial apply for
--- tags that have since disappeared; the insert above can't remove those.
-DELETE FROM "public"."tag_counts" tc
-WHERE NOT EXISTS (
-    SELECT 1 FROM "public"."document_tags" dt WHERE dt.tag = tc.tag
-);
+SELECT tag, COUNT(*) FROM "public"."document_tags" GROUP BY tag;
 
 -- ---------------------------------------------------------------------------
 -- Differential document_tags sync, gated on tags actually changing.


### PR DESCRIPTION
## What happened on the #335 deploy

[Run 28629941324](https://github.com/hyperlink-academy/leaflet/actions/runs/28629941324) got past the locking cleanly (no deadlock this time) but hit the ~2 minute role statement timeout on the stale-counts cleanup:

```
ERROR: canceling statement due to statement timeout (SQLSTATE 57014)
At statement 12: DELETE FROM tag_counts tc WHERE NOT EXISTS (
  SELECT 1 FROM document_tags dt WHERE dt.tag = tc.tag)
```

It was **executing** for those 2 minutes, not lock-waiting — the transaction's 15s `lock_timeout` would have cancelled a lock wait far earlier. Probing `document_tags` for a tag that no longer exists (exactly the rows the cleanup targets) crawls through every dead index entry the old churny trigger left behind for that tag value before concluding nothing is live — and 2½ days of blanket delete+reinsert on the firehose path left plenty.

## The fix

- Since the migration already holds exclusive locks on the tables, skip the reconciliation entirely: `DELETE FROM tag_counts` wholesale (it's a small rollup) and rebuild with one plain aggregate pass — no anti-join, no probes into dead index regions, no plan for the optimizer to get wrong.
- `SET LOCAL statement_timeout = '10min'` inside the transaction so the backfill isn't at the mercy of the role default as the tables grow; `lock_timeout = '15s'` still bounds any lock wait.

The failed migration was again not recorded in `schema_migrations`, so merging this retries it. After it lands, a one-off `VACUUM (ANALYZE) public.document_tags;` is worth running to reclaim the churn bloat that made this timeout possible in the first place.

## Verification (checklist)

- it looks good on both mobile and desktop — n/a, migration-only change
- it undo's like it ought to — n/a
- it handles keyboard interactions reasonably well — n/a
- no build errors!!! — verified on Postgres 16 in autocommit mode against both a fresh schema and a reproduction of the half-applied production state: clean apply, stale count rows gone, zero `tag_counts` drift, both functions present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWzh6uWz3ZZht2nmveFiJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWzh6uWz3ZZht2nmveFiJG)_