### PR TITLE
Collapse inter-tag whitespace in RSS feed output

### DIFF
--- a/actions/publishToPublication.ts
+++ b/actions/publishToPublication.ts
@@ -283,8 +283,13 @@ export async function publishToPublication({
     description !== undefined ? description : existingRecord.description;
   const resolvedTags = tags !== undefined ? tags : existingRecord.tags;
   const resolvedCoverImage = coverImageBlob ?? existingRecord.coverImage;
+  // Feeds and sort orders choke on unparseable dates, so only accept a
+  // publishedAt that parses.
+  const isValidDate = (v: string | undefined) =>
+    !!v && !isNaN(new Date(v).getTime());
   const resolvedPublishedAt =
-    publishedAt || existingRecord.publishedAt || new Date().toISOString();
+    [publishedAt, existingRecord.publishedAt].find(isValidDate) ||
+    new Date().toISOString();
 
   // Create record based on the document type
   let record: PubLeafletDocument.Record | SiteStandardDocument.Record;

--- a/app/(app)/lish/[did]/[publication]/[rkey]/StaticPostContent.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/StaticPostContent.tsx
@@ -27,14 +27,18 @@ function StaticBaseTextBlock(props: Omit<TextBlockCoreProps, "renderers">) {
 export function StaticPostContent({
   blocks,
   did,
+  baseUrl,
 }: {
   blocks: PubLeafletPagesLinearDocument.Block[];
   did: string;
+  // Absolute origin for blob image URLs — feed contexts have no document
+  // origin to resolve relative /api/atproto_images paths against.
+  baseUrl?: string;
 }) {
   return (
     <div className="postContent footnote-scope flex flex-col">
       {blocks.map((b, index) => {
-        return <Block block={b} did={did} key={index} />;
+        return <Block block={b} did={did} baseUrl={baseUrl} key={index} />;
       })}
     </div>
   );
@@ -43,10 +47,12 @@ export function StaticPostContent({
 let Block = async ({
   block,
   did,
+  baseUrl,
   isList,
 }: {
   block: PubLeafletPagesLinearDocument.Block;
   did: string;
+  baseUrl?: string;
   isList?: boolean;
 }) => {
   let b = block;
@@ -89,7 +95,7 @@ let Block = async ({
       return (
         <ul>
           {b.block.children.map((child, index) => (
-            <ListItem item={child} did={did} key={index} />
+            <ListItem item={child} did={did} baseUrl={baseUrl} key={index} />
           ))}
         </ul>
       );
@@ -103,7 +109,7 @@ let Block = async ({
             <div
               className={`imagePreview w-[120px] m-2 -mb-2 bg-cover shrink-0 rounded-t-md border border-border rotate-[4deg] origin-center relative`}
               style={{
-                backgroundImage: `url(${blobRefToSrc(b.block.previewImage?.ref, did)})`,
+                backgroundImage: `url(${blobRefToSrc(b.block.previewImage?.ref, did, baseUrl)})`,
                 backgroundPosition: "center",
               }}
             />
@@ -117,7 +123,7 @@ let Block = async ({
           alt={b.block.alt}
           height={b.block.aspectRatio?.height}
           width={b.block.aspectRatio?.width}
-          src={blobRefToSrc(b.block.image.ref, did)}
+          src={blobRefToSrc(b.block.image.ref, did, baseUrl)}
         />
       );
     }
@@ -135,7 +141,7 @@ let Block = async ({
               alt={image.alt}
               height={image.aspectRatio.height}
               width={image.aspectRatio.width}
-              src={blobRefToSrc(image.image.ref, did)}
+              src={blobRefToSrc(image.image.ref, did, baseUrl)}
             />
           ))}
         </div>
@@ -186,6 +192,7 @@ let Block = async ({
 function ListItem(props: {
   item: PubLeafletBlocksUnorderedList.ListItem;
   did: string;
+  baseUrl?: string;
   className?: string;
 }) {
   let isChecklist = props.item.checked !== undefined;
@@ -200,13 +207,19 @@ function ListItem(props: {
         </div>
       )}
       <div className="flex flex-col">
-        <Block block={{ block: props.item.content }} did={props.did} isList />
+        <Block
+          block={{ block: props.item.content }}
+          did={props.did}
+          baseUrl={props.baseUrl}
+          isList
+        />
         {props.item.children?.length ? (
           <ul className="-ml-[7px] sm:ml-[7px]">
             {props.item.children.map((child, index) => (
               <ListItem
                 item={child}
                 did={props.did}
+                baseUrl={props.baseUrl}
                 key={index}
                 className={props.className}
               />

--- a/app/(app)/lish/[did]/[publication]/[rkey]/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata(props: {
       feedTypes = {
         "application/rss+xml": `${pubRecord.url}/rss`,
         "application/atom+xml": `${pubRecord.url}/atom`,
-        "application/json": `${pubRecord.url}/json`,
+        "application/feed+json": `${pubRecord.url}/json`,
       };
     }
   }

--- a/app/(app)/lish/[did]/[publication]/generateFeed.ts
+++ b/app/(app)/lish/[did]/[publication]/generateFeed.ts
@@ -109,10 +109,7 @@ export async function generateFeed(
     })
     .slice(0, FEED_ITEM_LIMIT);
 
-  const newest = docs.reduce<Date | null>((acc, d) => {
-    const t = parseDate(d.documents?.sort_date);
-    return t && (!acc || t > acc) ? t : acc;
-  }, null);
+  const newest = parseDate(docs[0]?.documents?.sort_date);
 
   const feed = new Feed({
     title: stripInvalidXmlChars(name),
@@ -170,19 +167,7 @@ export async function generateFeed(
           baseUrl: pubUrl,
         }),
       );
-      const reader = stream.getReader();
-      const decoder = new TextDecoder();
-      const chunks: string[] = [];
-
-      let done, value;
-      while (!done) {
-        ({ done, value } = await reader.read());
-        if (value) {
-          chunks.push(decoder.decode(value, { stream: true }));
-        }
-      }
-
-      content = chunks.join("");
+      content = await new Response(stream).text();
       // Strip <link> preload tags injected by React SSR — they trigger
       // security warnings in RSS validators and aren't useful in feeds.
       content = content.replace(/<link\b[^>]*>/gi, "");

--- a/app/(app)/lish/[did]/[publication]/generateFeed.ts
+++ b/app/(app)/lish/[did]/[publication]/generateFeed.ts
@@ -9,9 +9,19 @@ import {
   normalizePublicationRecord,
   normalizeDocumentRecord,
   hasLeafletContent,
+  isLeafletPublication,
 } from "src/utils/normalizeRecords";
 import { publicationNameOrUriFilter } from "src/utils/uriHelpers";
-import { getDocumentURL } from "app/(app)/lish/createPub/getPublicationURL";
+import {
+  getDocumentURL,
+  getPublicationURL,
+} from "app/(app)/lish/createPub/getPublicationURL";
+
+// Readers poll feeds constantly and every item is a full React SSR render
+// (including shiki highlighting for code blocks), so cap the feed at the
+// most recent posts instead of rendering a publication's entire history
+// on each request.
+const FEED_ITEM_LIMIT = 50;
 
 // The feed library pretty-prints, leaving `<link>url</link>` followed by a
 // newline and indentation. `<link>` is a void element in HTML, so consumers
@@ -26,6 +36,22 @@ export function collapseInterTagWhitespace(xml: string): string {
     .join("");
 }
 
+// XML 1.0 forbids most C0 control characters even inside CDATA, and records
+// can carry them (lexicon string validation doesn't reject control chars).
+// One bad character in a title would make the whole feed unparseable.
+function stripInvalidXmlChars(s: string): string {
+  return s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "");
+}
+
+// Records can carry unparseable date strings (the publish action accepts the
+// caller's publishedAt verbatim), and an Invalid Date makes feed.atom1() and
+// feed.json1() throw for the whole publication.
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}
+
 export async function generateFeed(
   did: string,
   publication_name: string,
@@ -37,7 +63,6 @@ export async function generateFeed(
     .from("publications")
     .select(
       `*,
-        publication_subscriptions(*),
       documents_in_publications(documents(*))
       `,
     )
@@ -45,36 +70,72 @@ export async function generateFeed(
     .or(publicationNameOrUriFilter(did, publication_name))
     .order("uri", { ascending: false })
     .limit(1);
-  console.log(error);
+  if (error) {
+    // A transient query failure should surface as retryable to feed readers —
+    // many of them permanently drop subscriptions after repeated 404s.
+    console.error(error);
+    return new NextResponse(null, { status: 500 });
+  }
   let publication = publications?.[0];
+  if (!publication) return new NextResponse(null, { status: 404 });
 
-  const pubRecord = normalizePublicationRecord(publication?.record);
-  if (!publication || !pubRecord)
-    return new NextResponse(null, { status: 404 });
+  const pubRecord = normalizePublicationRecord(publication.record);
+  // Legacy pub.leaflet publications without a configured domain don't
+  // normalize (no URL), but they're still browsable at leaflet.pub/lish/…,
+  // so serve their feed from there rather than 404ing.
+  const rawRecord = isLeafletPublication(publication.record)
+    ? publication.record
+    : null;
+  const name = pubRecord?.name ?? rawRecord?.name;
+  if (!name) return new NextResponse(null, { status: 404 });
+  const absolutize = (url: string) =>
+    url.startsWith("/") ? `https://leaflet.pub${url}` : url;
+  const pubInput = { uri: publication.uri, record: publication.record };
+  const pubUrl = absolutize(pubRecord?.url ?? getPublicationURL(pubInput)).replace(
+    /\/$/,
+    "",
+  );
+  const description = pubRecord?.description ?? rawRecord?.description;
+
+  let docs = publication.documents_in_publications
+    .sort((a, b) => {
+      const dateA = a.documents?.sort_date
+        ? new Date(a.documents.sort_date).getTime()
+        : 0;
+      const dateB = b.documents?.sort_date
+        ? new Date(b.documents.sort_date).getTime()
+        : 0;
+      return dateB - dateA; // Sort in descending order (newest first)
+    })
+    .slice(0, FEED_ITEM_LIMIT);
+
+  const newest = docs.reduce<Date | null>((acc, d) => {
+    const t = parseDate(d.documents?.sort_date);
+    return t && (!acc || t > acc) ? t : acc;
+  }, null);
 
   const feed = new Feed({
-    title: pubRecord.name,
-    description: pubRecord.description,
-    id: pubRecord.url,
-    link: pubRecord.url,
+    title: stripInvalidXmlChars(name),
+    // feed@5.1.0 renders an undefined description as the literal string
+    // "undefined" in RSS, and RSS 2.0 requires the element regardless.
+    description: stripInvalidXmlChars(description || name),
+    id: pubUrl,
+    link: pubUrl,
     language: "en", // optional, used only in RSS 2.0, possible values: http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
     copyright: "",
+    // Without `updated` the library stamps render time into lastBuildDate /
+    // <updated>, so the feed byte-changes on every request even with no new
+    // posts, defeating readers' change detection.
+    updated: newest ?? new Date(0),
+    // Atom requires a feed-level author when entries carry none.
+    author: { name, link: pubUrl },
     feedLinks: {
-      rss: `${pubRecord.url}/rss`,
-      atom: `${pubRecord.url}/atom`,
-      json: `${pubRecord.url}/json`,
+      rss: `${pubUrl}/rss`,
+      atom: `${pubUrl}/atom`,
+      json: `${pubUrl}/json`,
     },
   });
 
-  let docs = publication.documents_in_publications.sort((a, b) => {
-    const dateA = a.documents?.sort_date
-      ? new Date(a.documents.sort_date).getTime()
-      : 0;
-    const dateB = b.documents?.sort_date
-      ? new Date(b.documents.sort_date).getTime()
-      : 0;
-    return dateB - dateA; // Sort in descending order (newest first)
-  });
   for (const doc of docs) {
     if (!doc.documents) continue;
     const record = normalizeDocumentRecord(
@@ -82,7 +143,6 @@ export async function generateFeed(
       doc.documents?.uri,
     );
     const uri = new AtUri(doc.documents?.uri);
-    const rkey = uri.rkey;
     if (!record) continue;
 
     let blocks: PubLeafletPagesLinearDocument.Block[] = [];
@@ -92,39 +152,61 @@ export async function generateFeed(
         blocks = firstPage.blocks || [];
       }
     }
-    const stream = await renderToReadableStream(
-      createElement(StaticPostContent, { blocks, did: uri.host }),
-    );
-    const reader = stream.getReader();
-    const chunks = [];
 
-    let done, value;
-    while (!done) {
-      ({ done, value } = await reader.read());
-      if (value) {
-        chunks.push(new TextDecoder().decode(value));
+    const docUrl = absolutize(
+      getDocumentURL(record, doc.documents.uri, pubRecord ?? pubInput),
+    );
+
+    let content: string;
+    if (blocks.length === 0) {
+      // Canvas pages and externally-authored documents have no linear blocks
+      // to render; link out instead of shipping an empty body.
+      content = `<p><a href="${docUrl}">View this post on the web</a></p>`;
+    } else {
+      const stream = await renderToReadableStream(
+        createElement(StaticPostContent, {
+          blocks,
+          did: uri.host,
+          baseUrl: pubUrl,
+        }),
+      );
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+
+      let done, value;
+      while (!done) {
+        ({ done, value } = await reader.read());
+        if (value) {
+          chunks.push(decoder.decode(value, { stream: true }));
+        }
       }
+
+      content = chunks.join("");
+      // Strip <link> preload tags injected by React SSR — they trigger
+      // security warnings in RSS validators and aren't useful in feeds.
+      content = content.replace(/<link\b[^>]*>/gi, "");
+      // Convert relative URLs to absolute so RSS readers can resolve them.
+      content = content.replace(/(src|href)="\/(?!\/)/g, `$1="${pubUrl}/`);
     }
 
-    let content = chunks.join("");
-    // Strip <link> preload tags injected by React SSR — they trigger
-    // security warnings in RSS validators and aren't useful in feeds.
-    content = content.replace(/<link\b[^>]*>/gi, "");
-    // Convert relative URLs to absolute so RSS readers can resolve them.
-    const baseUrl = pubRecord.url.replace(/\/$/, "");
-    content = content.replace(
-      /(src|href)="\/(?!\/)/g,
-      `$1="${baseUrl}/`,
-    );
+    const date =
+      parseDate(record.publishedAt) ??
+      parseDate(doc.documents.sort_date) ??
+      new Date(0);
 
-    const docUrl = getDocumentURL(record, doc.documents.uri, pubRecord);
     feed.addItem({
-      title: record.title,
-      description: record.description,
-      date: record.publishedAt ? new Date(record.publishedAt) : new Date(),
+      title: stripInvalidXmlChars(record.title || ""),
+      description: record.description
+        ? stripInvalidXmlChars(record.description)
+        : undefined,
+      date,
+      // `date` alone only maps to date_modified/<updated>; readers want the
+      // publish date too (Atom <published>, JSON Feed date_published).
+      published: date,
       id: docUrl,
       link: docUrl,
-      content,
+      content: stripInvalidXmlChars(content),
     });
   }
 

--- a/app/(app)/lish/[did]/[publication]/generateFeed.ts
+++ b/app/(app)/lish/[did]/[publication]/generateFeed.ts
@@ -13,6 +13,19 @@ import {
 import { publicationNameOrUriFilter } from "src/utils/uriHelpers";
 import { getDocumentURL } from "app/(app)/lish/createPub/getPublicationURL";
 
+// The feed library pretty-prints, leaving `<link>url</link>` followed by a
+// newline and indentation. `<link>` is a void element in HTML, so consumers
+// that parse RSS with an HTML parser drop the closing tag and read the URL
+// merged with the trailing indentation — then request paths like
+// "/{rkey}%0A%20%20...". Collapsing inter-tag whitespace (outside CDATA,
+// which holds post content) leaves those parsers a clean URL.
+export function collapseInterTagWhitespace(xml: string): string {
+  return xml
+    .split(/(<!\[CDATA\[[\s\S]*?\]\]>)/)
+    .map((part, i) => (i % 2 === 1 ? part : part.replace(/>\s+</g, "><")))
+    .join("");
+}
+
 export async function generateFeed(
   did: string,
   publication_name: string,

--- a/app/(app)/lish/[did]/[publication]/json/route.ts
+++ b/app/(app)/lish/[did]/[publication]/json/route.ts
@@ -19,6 +19,7 @@ export async function GET(
   return new Response(feed.json1(), {
     headers: {
       "Content-Type": "application/feed+json",
+      "Cache-Control": "s-maxage=300, stale-while-revalidate=3600",
       "CDN-Cache-Control": "s-maxage=300, stale-while-revalidate=3600",
     },
   });

--- a/app/(app)/lish/[did]/[publication]/layout.tsx
+++ b/app/(app)/lish/[did]/[publication]/layout.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata(props: {
           types: {
             "application/rss+xml": `${pubRecord.url}/rss`,
             "application/atom+xml": `${pubRecord.url}/atom`,
-            "application/json": `${pubRecord.url}/json`,
+            "application/feed+json": `${pubRecord.url}/json`,
           },
         }
       : undefined,

--- a/app/(app)/lish/[did]/[publication]/rss/route.ts
+++ b/app/(app)/lish/[did]/[publication]/rss/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { generateFeed } from "../generateFeed";
+import { collapseInterTagWhitespace, generateFeed } from "../generateFeed";
 
 export async function GET(
   req: Request,
@@ -16,7 +16,7 @@ export async function GET(
     return feed;
   }
 
-  return new Response(feed.rss2(), {
+  return new Response(collapseInterTagWhitespace(feed.rss2()), {
     headers: {
       "Content-Type": "application/rss+xml",
       "Cache-Control": "s-maxage=300, stale-while-revalidate=3600",

--- a/src/utils/uriHelpers.ts
+++ b/src/utils/uriHelpers.ts
@@ -36,7 +36,7 @@ export function publicationNameOrUriFilter(
   nameOrRkey: string,
 ): string {
   let standard, legacy;
-  if (/^(?!\.$|\.\.S)[A-Za-z0-9._:~-]{1,512}$/.test(nameOrRkey)) {
+  if (/^(?!\.$|\.\.$)[A-Za-z0-9._:~-]{1,512}$/.test(nameOrRkey)) {
     standard = AtUri.make(
       did,
       ids.SiteStandardPublication,
@@ -44,5 +44,8 @@ export function publicationNameOrUriFilter(
     ).toString();
     legacy = AtUri.make(did, ids.PubLeafletPublication, nameOrRkey).toString();
   }
-  return `name.eq."${nameOrRkey}"",uri.eq."${standard}",uri.eq."${legacy}"`;
+  // The name comes straight from the URL path; escape PostgREST's
+  // quoted-value metacharacters so it can't break the filter grammar.
+  const quotedName = `"${nameOrRkey.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return `name.eq.${quotedName},uri.eq."${standard}",uri.eq."${legacy}"`;
 }


### PR DESCRIPTION
The feed library pretty-prints RSS, leaving <link>url</link> followed by
a newline and 12 spaces of indentation. <link> is a void element in HTML,
so feed consumers that parse RSS with an HTML parser drop the closing tag
and read the URL merged with the trailing indentation, then request paths
like /{rkey}%0A%20%20%20... on publication domains.

Minify whitespace between tags (outside CDATA, which holds post content)
so those parsers extract clean URLs. Atom is unaffected: its link element
carries the URL in an href attribute.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014T8MnGwc7K4bWKrjGJB87Y