### PR TITLE
Fix: footnote number ordering

### DIFF
--- a/components/Pages/Page.tsx
+++ b/components/Pages/Page.tsx
@@ -147,6 +147,7 @@ export const PageWrapper = (props: {
         id={props.id}
         className={`
       pageScrollWrapper
+      footnote-scope
       publicationScrollContainer
       grow relative
       shrink-0 snap-center
@@ -171,7 +172,7 @@ export const PageWrapper = (props: {
 `}
       >
         <div
-          className={`postPageContent footnote-scope static
+          className={`postPageContent static
           ${props.fullPageScroll ? "sm:max-w-[var(--page-width-units)] mx-auto" : ` contents w-full ${props.flow ? "" : "h-full"}`}
         `}
         >


### PR DESCRIPTION
Fixes an occasional issue where a user creating footnotes in random order will find that they all use "1" in the body text, even when they're number 2, 3, etc. This includes renumbering (which the side bar and footer displays already handle correctly). The issue was a scope-level problem where it was referencing a counter that didn't always exist.