### PR TITLE
Optimize domain route caching with Vercel waitUntil

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { AtUri } from "@atproto/syntax";
 import { createClient } from "@supabase/supabase-js";
-import { getCache } from "@vercel/functions";
+import { getCache, waitUntil } from "@vercel/functions";
 import { NextRequest, NextResponse } from "next/server";
 import { Database } from "supabase/database.types";
 import { isMainSiteHost } from "src/utils/customDomain";
@@ -35,7 +35,7 @@ async function getDomainRoutes(hostname: string) {
   let { data } = await supabase
     .from("custom_domains")
     .select(
-      "*, custom_domain_routes(*), publication_domains(*, publications(*))",
+      "domain, custom_domain_routes(route, view_permission_token), publication_domains(publications(uri))",
     )
     .eq("domain", hostname)
     .single();
@@ -67,12 +67,14 @@ export default async function middleware(req: NextRequest) {
   if (!routes) {
     routes = await getDomainRoutes(hostname);
     if (routes) {
-      try {
-        await cache.set(`domain:${hostname}`, routes, {
-          ttl: 60,
-          tags: [`domain:${hostname}`],
-        });
-      } catch {}
+      waitUntil(
+        cache
+          .set(`domain:${hostname}`, routes, {
+            ttl: 60,
+            tags: [`domain:${hostname}`],
+          })
+          .catch(() => {}),
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Refactors the domain route caching logic to use Vercel's `waitUntil` API for non-blocking cache writes. This allows the middleware to return a response immediately without waiting for the cache operation to complete.

### Changes

- Import `waitUntil` from `@vercel/functions`
- Wrap the cache.set operation in `waitUntil()` to execute asynchronously after the response is sent
- Optimize the Supabase query to select only necessary fields (`domain`, `route`, `view_permission_token`, `uri`) instead of fetching all columns with wildcards

### Benefits

- **Improved response time**: Middleware no longer blocks on cache writes
- **Reduced query overhead**: Only fetches required fields from the database
- **Better resource utilization**: Cache operations run in the background without delaying the response

## Before you pull, have you made sure...

- ✅ No build errors
- ✅ Middleware logic remains functionally equivalent
- ✅ Cache behavior preserved (same TTL and tags)

https://claude.ai/code/session_01Tuq4YL6kpneaimzk8SV4Dm