### PR TITLE
Fix critical and major billing/correctness issues from paid-memberships review

### DIFF
--- a/actions/publications/joinMembership.ts
+++ b/actions/publications/joinMembership.ts
@@ -238,6 +238,42 @@ export async function subscribeToTier(args: {
       return Err("stripe_error");
     }
 
+    // Concurrent joins (different tier/cadence, so different idempotency keys)
+    // can each create a live subscription while only one row survives the
+    // upsert. Cancel any older live subscription for this reader+publication so
+    // exactly one keeps billing; ties break by id so racing requests can't
+    // cancel each other. The connect-events webhook reconciles the row if the
+    // survivor isn't the one it points at.
+    try {
+      const siblings = await stripe.subscriptions.list(
+        { customer: connectedCustomerId, status: "all", limit: 100 },
+        { stripeAccount },
+      );
+      for (const other of siblings.data) {
+        if (other.id === subscription.id) continue;
+        if (other.metadata?.kind !== "publication_membership") continue;
+        if (other.metadata?.publication !== args.publicationUri) continue;
+        if (other.status === "canceled" || other.status === "incomplete_expired")
+          continue;
+        if (
+          other.created > subscription.created ||
+          (other.created === subscription.created &&
+            other.id > subscription.id)
+        )
+          continue;
+        await stripe.subscriptions
+          .cancel(other.id, undefined, { stripeAccount })
+          .catch((e) =>
+            console.error(
+              `[joinMembership] failed to cancel duplicate subscription ${other.id}:`,
+              e,
+            ),
+          );
+      }
+    } catch (e) {
+      console.error("[joinMembership] duplicate subscription sweep failed:", e);
+    }
+
     if (subscription.status === "active" || subscription.status === "trialing")
       return Ok({ status: "active", hostedInvoiceUrl: null });
 

--- a/actions/publications/joinMembership.ts
+++ b/actions/publications/joinMembership.ts
@@ -12,8 +12,10 @@ import {
   walletCheckoutSessionCard,
 } from "stripe/wallet";
 import { isActiveMembership } from "src/membership";
-import { getReaderMembership } from "src/membership.server";
-import { notifyNewMember } from "src/notifications";
+import {
+  getReaderMembership,
+  notifyNewMember,
+} from "src/membership.server";
 import { Ok, Err, type Result } from "src/result";
 
 type CheckoutSessionError = "not_authenticated" | "stripe_error";

--- a/actions/publications/joinMembership.ts
+++ b/actions/publications/joinMembership.ts
@@ -13,6 +13,7 @@ import {
 } from "stripe/wallet";
 import { isActiveMembership } from "src/membership";
 import { getReaderMembership } from "src/membership.server";
+import { notifyNewMember } from "src/notifications";
 import { Ok, Err, type Result } from "src/result";
 
 type CheckoutSessionError = "not_authenticated" | "stripe_error";
@@ -157,11 +158,49 @@ export async function subscribeToTier(args: {
       existing.stripe_account_id &&
       !isActiveMembership(existing)
     ) {
-      await stripe.subscriptions
-        .cancel(existing.stripe_subscription_id, undefined, {
+      // The row can look lapsed just because a renewal webhook was missed;
+      // only Stripe knows whether the subscription is still billing, and
+      // canceling a live one here would kill a paid-up membership with no
+      // refund.
+      const liveSub = await stripe.subscriptions
+        .retrieve(existing.stripe_subscription_id, {
           stripeAccount: existing.stripe_account_id,
         })
-        .catch(() => {});
+        .catch((e) => {
+          if ((e as { code?: string })?.code === "resource_missing")
+            return null;
+          throw e;
+        });
+      if (
+        liveSub &&
+        (liveSub.status === "active" || liveSub.status === "trialing")
+      ) {
+        const livePeriodEnd = liveSub.items.data[0]?.current_period_end ?? 0;
+        const { error } = await supabaseServerClient
+          .from("publication_memberships")
+          .update({
+            status: liveSub.status,
+            current_period_end: livePeriodEnd
+              ? new Date(livePeriodEnd * 1000).toISOString()
+              : null,
+            cancel_at_period_end: liveSub.cancel_at_period_end ?? false,
+            updated_at: new Date().toISOString(),
+          })
+          .eq("id", existing.id);
+        if (error)
+          console.error(
+            "[joinMembership] membership refresh from stripe failed:",
+            error,
+          );
+        return Err("already_member");
+      }
+      if (liveSub) {
+        await stripe.subscriptions
+          .cancel(existing.stripe_subscription_id, undefined, {
+            stripeAccount: existing.stripe_account_id,
+          })
+          .catch(() => {});
+      }
     }
 
     const connectedCustomerId = await getOrCreateConnectedCustomer(
@@ -212,7 +251,7 @@ export async function subscribeToTier(args: {
         ? subscription.latest_invoice
         : null;
 
-    const { error } = await supabaseServerClient
+    const { data: membershipRow, error } = await supabaseServerClient
       .from("publication_memberships")
       .upsert(
         {
@@ -232,10 +271,28 @@ export async function subscribeToTier(args: {
           updated_at: new Date().toISOString(),
         },
         { onConflict: "publication,identity_id" },
-      );
-    if (error) {
+      )
+      .select("id")
+      .single();
+    if (error || !membershipRow) {
       console.error("[joinMembership] membership upsert failed:", error);
       return Err("stripe_error");
+    }
+
+    // The webhook only notifies on an inactive→active transition, and this
+    // row is already active by the time its events arrive — so the inline
+    // join is what notifies the publisher (notifyNewMember dedupes against
+    // the webhook's reconciliation path). A notification failure shouldn't
+    // fail a join that already billed.
+    if (
+      subscription.status === "active" ||
+      subscription.status === "trialing"
+    ) {
+      try {
+        await notifyNewMember(args.publicationUri, membershipRow.id);
+      } catch (e) {
+        console.error("[joinMembership] new member notification failed:", e);
+      }
     }
 
     // Concurrent joins (different tier/cadence, so different idempotency keys)

--- a/actions/publications/membershipSettings.ts
+++ b/actions/publications/membershipSettings.ts
@@ -137,6 +137,9 @@ export async function upsertMembershipTier(
         monthly_price_cents: tier.monthly_price_cents,
         annual_price_cents: tier.annual_price_cents ?? null,
         sort_order: tier.sort_order ?? 0,
+        // Not offered to readers until Stripe provisioning succeeds; the
+        // final update below flips it on.
+        active: false,
       })
       .select("id")
       .single();
@@ -151,6 +154,7 @@ export async function upsertMembershipTier(
   let productId = existing?.stripe_product_id ?? null;
   let monthlyPriceId = existing?.stripe_price_monthly_id ?? null;
   let annualPriceId = existing?.stripe_price_annual_id ?? null;
+  const pricesToArchive: string[] = [];
 
   try {
     if (productId) {
@@ -179,28 +183,26 @@ export async function upsertMembershipTier(
 
     // Stripe Prices are immutable: an amount change means a new Price and
     // deactivating the old one (existing subscriptions keep their old price).
+    // Replaced prices are only archived after the DB points at their
+    // successors: a leaked active price is harmless (checkout only uses ids
+    // from the DB), but a DB row pointing at an archived price bricks the
+    // tier for new members.
     const syncPrice = async (
       currentPriceId: string | null,
       currentAmount: number | null,
       newAmount: number | null,
       interval: "month" | "year",
     ): Promise<string | null> => {
-      if (newAmount == null) {
-        if (currentPriceId)
-          await stripe.prices.update(
-            currentPriceId,
-            { active: false },
-            { stripeAccount },
-          );
-        return null;
+      if (currentPriceId && currentAmount === newAmount && newAmount != null) {
+        // A previous sync failure may have left this price archived; verify
+        // before reusing so re-saving the same amount repairs the tier.
+        const current = await stripe.prices.retrieve(currentPriceId, {
+          stripeAccount,
+        });
+        if (current.active) return currentPriceId;
       }
-      if (currentPriceId && currentAmount === newAmount) return currentPriceId;
-      if (currentPriceId)
-        await stripe.prices.update(
-          currentPriceId,
-          { active: false },
-          { stripeAccount },
-        );
+      if (currentPriceId) pricesToArchive.push(currentPriceId);
+      if (newAmount == null) return null;
       const price = await stripe.prices.create(
         {
           product: productId!,
@@ -253,6 +255,14 @@ export async function upsertMembershipTier(
   if (error) {
     console.error("[membershipSettings] tier update failed:", error);
     return Err("database_error");
+  }
+
+  for (const priceId of pricesToArchive) {
+    await stripe.prices
+      .update(priceId, { active: false }, { stripeAccount })
+      .catch((e) =>
+        console.error("[membershipSettings] price archive failed:", e),
+      );
   }
   return Ok({ id: rowId });
 }

--- a/app/(app)/lish/[did]/[publication]/join/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/join/page.tsx
@@ -19,7 +19,7 @@ async function fetchPublicationForJoin(did: string, publicationName: string) {
     .select(
       `uri, name, identity_did, record,
        publication_membership_settings(enabled),
-       publication_membership_tiers(id, name, description, monthly_price_cents, annual_price_cents, currency, active, sort_order)`,
+       publication_membership_tiers(id, name, description, monthly_price_cents, annual_price_cents, currency, active, sort_order, stripe_price_monthly_id)`,
     )
     .eq("identity_did", did)
     .or(publicationNameOrUriFilter(did, publicationName))
@@ -53,7 +53,9 @@ export default async function JoinPage(props: {
 
   const record = normalizePublicationRecord(publication.record);
   const tiers = publication.publication_membership_tiers
-    .filter((t) => t.active)
+    // Requiring a monthly price id guards against half-provisioned tiers a
+    // reader couldn't actually subscribe to.
+    .filter((t) => t.active && t.stripe_price_monthly_id)
     .sort((a, b) => a.sort_order - b.sort_order)
     .map((t) => ({
       id: t.id,

--- a/app/api/inngest/functions/sync_document_metadata.ts
+++ b/app/api/inngest/functions/sync_document_metadata.ts
@@ -2,6 +2,7 @@ import { inngest, events } from "../client";
 import { supabaseServerClient } from "supabase/serverClient";
 import { AtpAgent, AtUri } from "@atproto/api";
 import { idResolver } from "src/identity";
+import { pageHasMembersDelimiter } from "src/membership";
 import type { Json } from "supabase/database.types";
 
 // 1m, 2m, 4m, 8m, 16m, 32m, 1h, 2h, 4h, 8h, 8h, 8h (~37h total)
@@ -109,6 +110,20 @@ export const sync_document_metadata = inngest.createFunction(
         .from("documents")
         .update({ data: inflatedRecord as Json })
         .eq("uri", document_uri);
+
+      // The appview skips the members_only flag for blob-offloaded records
+      // (the firehose payload has `pages: []`), so this is the only place it
+      // can be computed from the real pages; without it, flag-keyed surfaces
+      // would serve full gated content.
+      const site = record.site;
+      if (typeof site === "string" && site.startsWith("at://")) {
+        const { error } = await supabaseServerClient
+          .from("documents_in_publications")
+          .update({ members_only: pageHasMembersDelimiter(inflatedPages[0]) })
+          .eq("publication", site)
+          .eq("document", document_uri);
+        if (error) throw error;
+      }
 
       return { inflated: true, pageCount: inflatedPages.length };
     });

--- a/app/api/webhooks/stripe/connect-events/handlers.ts
+++ b/app/api/webhooks/stripe/connect-events/handlers.ts
@@ -1,13 +1,8 @@
 import type Stripe from "stripe";
 import { render } from "@react-email/render";
-import { AtUri } from "@atproto/syntax";
-import { v7 } from "uuid";
 import { getStripe } from "stripe/client";
 import { supabaseServerClient } from "supabase/serverClient";
-import {
-  type Notification,
-  pingIdentityToUpdateNotification,
-} from "src/notifications";
+import { notifyNewMember } from "src/notifications";
 import MembershipPaymentFailed from "emails/membershipPaymentFailed";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
@@ -27,9 +22,9 @@ function isActiveStatus(status: string | null | undefined): boolean {
 export async function handleMembershipSubscriptionEvent(
   sub: Stripe.Subscription,
   stripeAccount: string | undefined,
+  opts?: { fresh?: boolean },
 ) {
   if (!isMembershipSub(sub)) return;
-  const periodEnd = sub.items.data[0]?.current_period_end ?? 0;
 
   const { data: existing, error: readError } = await supabaseServerClient
     .from("publication_memberships")
@@ -43,6 +38,15 @@ export async function handleMembershipSubscriptionEvent(
     await reconcileUntrackedSubscription(sub, stripeAccount);
     return;
   }
+
+  // Event payloads are point-in-time snapshots and delivery order isn't
+  // guaranteed — a delayed `updated` (active) processed after `deleted`
+  // (canceled) would resurrect the membership. Write the subscription's
+  // current truth instead, unless the caller already re-fetched it.
+  if (!opts?.fresh && stripeAccount) {
+    sub = await getStripe().subscriptions.retrieve(sub.id, { stripeAccount });
+  }
+  const periodEnd = sub.items.data[0]?.current_period_end ?? 0;
 
   const wasActive = isActiveStatus(existing.status);
 
@@ -194,7 +198,7 @@ export async function handleMembershipInvoiceSucceeded(
   const sub = await getStripe().subscriptions.retrieve(subscriptionId, {
     stripeAccount,
   });
-  await handleMembershipSubscriptionEvent(sub, stripeAccount);
+  await handleMembershipSubscriptionEvent(sub, stripeAccount, { fresh: true });
 }
 
 export async function handleMembershipInvoiceFailed(
@@ -208,27 +212,13 @@ export async function handleMembershipInvoiceFailed(
 
   // No grace period: a failed renewal re-gates members-only content immediately
   // (isActiveMembership treats past_due as inactive); Stripe retries then cancels.
-  await supabaseServerClient
+  const { error } = await supabaseServerClient
     .from("publication_memberships")
     .update({ status: "past_due", updated_at: new Date().toISOString() })
     .eq("stripe_subscription_id", sub.id);
+  if (error) throw error;
 
   await sendPaymentFailedEmail(sub);
-}
-
-async function notifyNewMember(
-  publication: string | undefined,
-  membershipId: string,
-) {
-  if (!publication) return;
-  const recipient = new AtUri(publication).host;
-  const notification: Notification = {
-    id: v7(),
-    recipient,
-    data: { type: "new_member", publication, membership_id: membershipId },
-  };
-  await supabaseServerClient.from("notifications").insert(notification);
-  await pingIdentityToUpdateNotification(recipient);
 }
 
 async function sendPaymentFailedEmail(sub: Stripe.Subscription) {
@@ -236,7 +226,7 @@ async function sendPaymentFailedEmail(sub: Stripe.Subscription) {
   const identityId = sub.metadata.identity_id;
   if (!identityId) return;
 
-  const [{ data: identity }, { data: pub }] = await Promise.all([
+  const [identityRes, pubRes] = await Promise.all([
     supabaseServerClient
       .from("identities")
       .select("email")
@@ -248,8 +238,13 @@ async function sendPaymentFailedEmail(sub: Stripe.Subscription) {
           .select("name")
           .eq("uri", publication)
           .maybeSingle()
-      : Promise.resolve({ data: null }),
+      : Promise.resolve({ data: null, error: null }),
   ]);
+  // Throw so Stripe redelivers rather than silently dropping the email.
+  if (identityRes.error) throw identityRes.error;
+  if (pubRes.error) throw pubRes.error;
+  const identity = identityRes.data;
+  const pub = pubRes.data;
   if (!identity?.email) return;
 
   const updateCardUrl = new URL("/memberships", APP_URL).toString();

--- a/app/api/webhooks/stripe/connect-events/handlers.ts
+++ b/app/api/webhooks/stripe/connect-events/handlers.ts
@@ -21,8 +21,9 @@ function isActiveStatus(status: string | null | undefined): boolean {
 }
 
 // Reconcile a membership row from a connected-account subscription event. Keyed
-// on the subscription id, so a stale event for a since-replaced subscription
-// (cancel-and-recreate) matches no row and is a harmless no-op.
+// on the subscription id; events for subscriptions with no matching row fall
+// through to reconcileUntrackedSubscription, which can rebuild the row from the
+// subscription's metadata.
 export async function handleMembershipSubscriptionEvent(
   sub: Stripe.Subscription,
   stripeAccount: string | undefined,
@@ -30,16 +31,22 @@ export async function handleMembershipSubscriptionEvent(
   if (!isMembershipSub(sub)) return;
   const periodEnd = sub.items.data[0]?.current_period_end ?? 0;
 
-  const { data: existing } = await supabaseServerClient
+  const { data: existing, error: readError } = await supabaseServerClient
     .from("publication_memberships")
     .select("id, status")
     .eq("stripe_subscription_id", sub.id)
     .maybeSingle();
-  if (!existing) return;
+  // Throw so the route 500s and Stripe redelivers; treating a failed read as
+  // "no row" would misroute the event into reconciliation.
+  if (readError) throw readError;
+  if (!existing) {
+    await reconcileUntrackedSubscription(sub, stripeAccount);
+    return;
+  }
 
   const wasActive = isActiveStatus(existing.status);
 
-  await supabaseServerClient
+  const { error: writeError } = await supabaseServerClient
     .from("publication_memberships")
     .update({
       status: sub.status,
@@ -51,9 +58,132 @@ export async function handleMembershipSubscriptionEvent(
       updated_at: new Date().toISOString(),
     })
     .eq("stripe_subscription_id", sub.id);
+  if (writeError) throw writeError;
 
   if (isActiveStatus(sub.status) && !wasActive) {
     await notifyNewMember(sub.metadata.publication, existing.id);
+  }
+}
+
+// The join flow writes the membership row only after the Stripe subscription
+// already exists, so a failed write — or a row deleted later, e.g. by an
+// identity merge — leaves a live subscription billing the reader with no
+// record, no access, and no way to cancel. The subscription's metadata carries
+// everything needed to rebuild the row, making the webhook the reconciliation
+// path of last resort.
+async function reconcileUntrackedSubscription(
+  eventSub: Stripe.Subscription,
+  stripeAccount: string | undefined,
+) {
+  // Connected-account events always carry the account; without it we can't
+  // even re-fetch the subscription.
+  if (!stripeAccount) return;
+  const { publication, tier_id, identity_id, cadence } = eventSub.metadata;
+  if (!publication || !identity_id) {
+    console.error(
+      `[connect-events] membership subscription ${eventSub.id} has no publication/identity metadata; cannot reconcile`,
+    );
+    return;
+  }
+
+  // Event payloads are point-in-time snapshots and delivery order isn't
+  // guaranteed; since we're about to (re)create state from scratch, act only
+  // on the subscription's current truth.
+  const sub = await getStripe().subscriptions.retrieve(eventSub.id, {
+    stripeAccount,
+  });
+  if (sub.status === "canceled" || sub.status === "incomplete_expired") return;
+
+  const periodEnd = sub.items.data[0]?.current_period_end ?? 0;
+  const fields = {
+    cadence: cadence ?? null,
+    stripe_account_id: stripeAccount,
+    stripe_customer_id:
+      typeof sub.customer === "string" ? sub.customer : sub.customer.id,
+    stripe_subscription_id: sub.id,
+    stripe_price_id: sub.items.data[0]?.price.id ?? null,
+    status: sub.status,
+    current_period_end: periodEnd
+      ? new Date(periodEnd * 1000).toISOString()
+      : null,
+    cancel_at_period_end: sub.cancel_at_period_end ?? false,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data: tracked, error: trackedError } = await supabaseServerClient
+    .from("publication_memberships")
+    .select("id, status, stripe_subscription_id")
+    .eq("publication", publication)
+    .eq("identity_id", identity_id)
+    .maybeSingle();
+  if (trackedError) throw trackedError;
+
+  if (tracked) {
+    // The reader's row tracks a different subscription. If that one is live,
+    // don't clobber it — this event is either stale (a since-replaced
+    // subscription) or evidence of duplicate live billing that needs manual
+    // attention. If the tracked subscription is dead and this one is live,
+    // this is the survivor: take the row over.
+    if (isActiveStatus(tracked.status) || !isActiveStatus(sub.status)) {
+      if (isActiveStatus(sub.status)) {
+        console.error(
+          `[connect-events] live membership subscription ${sub.id} (${publication}, identity ${identity_id}) is not the tracked subscription ${tracked.stripe_subscription_id}; possible duplicate billing`,
+        );
+      }
+      return;
+    }
+    const { error } = await supabaseServerClient
+      .from("publication_memberships")
+      .update({ ...fields, tier: tier_id ?? null })
+      .eq("id", tracked.id);
+    if (error) throw error;
+    await notifyNewMember(publication, tracked.id);
+    return;
+  }
+
+  // FK guards: surface a permanently-unrecoverable insert loudly instead of
+  // retry-looping on it. A missing identity means the subscription is billing
+  // with no owner at all.
+  const [identityRes, tierRes] = await Promise.all([
+    supabaseServerClient
+      .from("identities")
+      .select("id")
+      .eq("id", identity_id)
+      .maybeSingle(),
+    tier_id
+      ? supabaseServerClient
+          .from("publication_membership_tiers")
+          .select("id")
+          .eq("id", tier_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+  ]);
+  if (identityRes.error) throw identityRes.error;
+  if (tierRes.error) throw tierRes.error;
+  if (!identityRes.data) {
+    console.error(
+      `[connect-events] membership subscription ${sub.id} references missing identity ${identity_id}; billing with no owner, needs manual cancellation`,
+    );
+    return;
+  }
+
+  const { data: inserted, error: insertError } = await supabaseServerClient
+    .from("publication_memberships")
+    .upsert(
+      {
+        publication,
+        identity_id,
+        tier: tierRes.data?.id ?? null,
+        ...fields,
+      },
+      { onConflict: "publication,identity_id" },
+    )
+    .select("id")
+    .single();
+  if (insertError) throw insertError;
+
+  if (isActiveStatus(sub.status)) {
+    await notifyNewMember(publication, inserted.id);
   }
 }
 

--- a/app/api/webhooks/stripe/connect-events/handlers.ts
+++ b/app/api/webhooks/stripe/connect-events/handlers.ts
@@ -2,7 +2,7 @@ import type Stripe from "stripe";
 import { render } from "@react-email/render";
 import { getStripe } from "stripe/client";
 import { supabaseServerClient } from "supabase/serverClient";
-import { notifyNewMember } from "src/notifications";
+import { notifyNewMember } from "src/membership.server";
 import MembershipPaymentFailed from "emails/membershipPaymentFailed";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";

--- a/app/api/webhooks/stripe/handle_checkout_completed.ts
+++ b/app/api/webhooks/stripe/handle_checkout_completed.ts
@@ -6,6 +6,10 @@ export async function handleCheckoutCompleted(sessionId: string) {
   const s = await getStripe().checkout.sessions.retrieve(sessionId, {
     expand: ["subscription"],
   });
+  // Setup-mode sessions (membership wallet card collection) also complete on
+  // the platform account; only Leaflet Pro subscription checkouts carry a
+  // client_reference_id and are provisioned here.
+  if (s.mode !== "subscription") return;
   const sub = typeof s.subscription === "object" ? s.subscription : null;
   const periodEnd = sub?.items.data[0]?.current_period_end ?? 0;
   const lookupKey = sub?.items.data[0]?.price.lookup_key ?? null;

--- a/src/membership.server.ts
+++ b/src/membership.server.ts
@@ -1,7 +1,47 @@
+import { AtUri } from "@atproto/syntax";
+import { v7 } from "uuid";
 import { supabaseServerClient } from "supabase/serverClient";
 import { getPublicationURL } from "app/(app)/lish/createPub/getPublicationURL";
+import {
+  type Notification,
+  pingIdentityToUpdateNotification,
+} from "src/notifications";
 
 // Server-side companions to src/membership.ts (which stays client-safe).
+// notifyNewMember lives here rather than in src/notifications.ts because that
+// module is "use server" — exporting it there would make it a wire-callable
+// action anyone could invoke with arbitrary publication/membership ids.
+
+// Notify the publication owner of a new member. Both the inline join flow and
+// the webhook (transition + reconciliation paths) can observe the same
+// activation, so dedupe on the membership id before inserting.
+export async function notifyNewMember(
+  publication: string | undefined,
+  membershipId: string,
+) {
+  if (!publication) return;
+  const recipient = new AtUri(publication).host;
+
+  const { data: existing, error: readError } = await supabaseServerClient
+    .from("notifications")
+    .select("id")
+    .eq("data->>type", "new_member")
+    .eq("data->>membership_id", membershipId)
+    .limit(1);
+  if (readError) throw readError;
+  if (existing && existing.length > 0) return;
+
+  const notification: Notification = {
+    id: v7(),
+    recipient,
+    data: { type: "new_member", publication, membership_id: membershipId },
+  };
+  const { error } = await supabaseServerClient
+    .from("notifications")
+    .insert(notification);
+  if (error) throw error;
+  await pingIdentityToUpdateNotification(recipient);
+}
 
 export async function getReaderMembership(
   publicationUri: string,

--- a/src/mergeIdentity.ts
+++ b/src/mergeIdentity.ts
@@ -125,6 +125,95 @@ export async function mergeEmailIdentityIntoAtpIdentity(args: {
         .set({ identity_id: targetId })
         .where(eq(custom_domains.identity_id, sourceId));
 
+      // Paid-membership state hangs off identities with ON DELETE CASCADE, so
+      // it must move before the source row is deleted — Stripe keeps billing
+      // the subscriptions either way.
+
+      // publication_memberships: unique (publication, identity_id). A live
+      // subscription must keep its row, so on collision the active side wins,
+      // target preferred on a tie. A dropped live row is logged for manual
+      // cancellation; the connect-events webhook also flags it on the
+      // subscription's next event.
+      await tx.execute(sql`
+        delete from publication_memberships t
+        where t.identity_id = ${targetId}
+          and t.status not in ('active', 'trialing')
+          and exists (
+            select 1 from publication_memberships s
+            where s.identity_id = ${sourceId}
+              and s.publication = t.publication
+              and s.status in ('active', 'trialing')
+          )
+      `);
+      const droppedMemberships = await tx.execute(sql`
+        delete from publication_memberships s
+        where s.identity_id = ${sourceId}
+          and exists (
+            select 1 from publication_memberships t
+            where t.identity_id = ${targetId}
+              and t.publication = s.publication
+          )
+        returning s.publication, s.stripe_subscription_id, s.status
+      `);
+      for (const row of droppedMemberships.rows as {
+        publication: string;
+        stripe_subscription_id: string | null;
+        status: string | null;
+      }[]) {
+        if (row.status === "active" || row.status === "trialing")
+          console.error(
+            `[mergeIdentity] dropped live membership ${row.stripe_subscription_id} (${row.publication}) on merge collision; needs manual cancellation`,
+          );
+      }
+      await tx.execute(sql`
+        update publication_memberships
+        set identity_id = ${targetId}
+        where identity_id = ${sourceId}
+      `);
+
+      // stripe_wallets: one per identity; target's wallet and saved card win.
+      await tx.execute(sql`
+        delete from stripe_wallets
+        where identity_id = ${sourceId}
+          and exists (select 1 from stripe_wallets where identity_id = ${targetId})
+      `);
+      await tx.execute(sql`
+        update stripe_wallets
+        set identity_id = ${targetId}
+        where identity_id = ${sourceId}
+      `);
+
+      // stripe_connected_customers: target wins on (identity, account)
+      // collision. A membership moved from source still carries source's
+      // customer id on its own row, so dropping the mapping doesn't orphan the
+      // subscription.
+      await tx.execute(sql`
+        delete from stripe_connected_customers s
+        where s.identity_id = ${sourceId}
+          and exists (
+            select 1 from stripe_connected_customers t
+            where t.identity_id = ${targetId}
+              and t.stripe_account_id = s.stripe_account_id
+          )
+      `);
+      await tx.execute(sql`
+        update stripe_connected_customers
+        set identity_id = ${targetId}
+        where identity_id = ${sourceId}
+      `);
+
+      // stripe_connected_accounts: one per identity; target wins.
+      await tx.execute(sql`
+        delete from stripe_connected_accounts
+        where identity_id = ${sourceId}
+          and exists (select 1 from stripe_connected_accounts where identity_id = ${targetId})
+      `);
+      await tx.execute(sql`
+        update stripe_connected_accounts
+        set identity_id = ${targetId}
+        where identity_id = ${sourceId}
+      `);
+
       // identities.email is unique — step via NULL so we don't collide
       // mid-swap. custom_domains.identity is nullable and cascades on update;
       // we re-set it explicitly after the final value lands because NULL→value

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -3,7 +3,6 @@
 import { supabaseServerClient } from "supabase/serverClient";
 import { Tables, TablesInsert } from "supabase/database.types";
 import { AtUri } from "@atproto/syntax";
-import { v7 } from "uuid";
 import { idResolver, getProfiles, type Profile } from "src/identity";
 import {
   normalizeDocumentRecord,
@@ -696,37 +695,6 @@ async function hydrateNewMemberNotifications(notifications: NotificationRow[]) {
         ),
       };
     });
-}
-
-// Notify the publication owner of a new member. Both the inline join flow and
-// the webhook (transition + reconciliation paths) can observe the same
-// activation, so dedupe on the membership id before inserting.
-export async function notifyNewMember(
-  publication: string | undefined,
-  membershipId: string,
-) {
-  if (!publication) return;
-  const recipient = new AtUri(publication).host;
-
-  const { data: existing, error: readError } = await supabaseServerClient
-    .from("notifications")
-    .select("id")
-    .eq("data->>type", "new_member")
-    .eq("data->>membership_id", membershipId)
-    .limit(1);
-  if (readError) throw readError;
-  if (existing && existing.length > 0) return;
-
-  const notification: Notification = {
-    id: v7(),
-    recipient,
-    data: { type: "new_member", publication, membership_id: membershipId },
-  };
-  const { error } = await supabaseServerClient
-    .from("notifications")
-    .insert(notification);
-  if (error) throw error;
-  await pingIdentityToUpdateNotification(recipient);
 }
 
 export async function pingIdentityToUpdateNotification(did: string) {

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -3,6 +3,7 @@
 import { supabaseServerClient } from "supabase/serverClient";
 import { Tables, TablesInsert } from "supabase/database.types";
 import { AtUri } from "@atproto/syntax";
+import { v7 } from "uuid";
 import { idResolver, getProfiles, type Profile } from "src/identity";
 import {
   normalizeDocumentRecord,
@@ -695,6 +696,37 @@ async function hydrateNewMemberNotifications(notifications: NotificationRow[]) {
         ),
       };
     });
+}
+
+// Notify the publication owner of a new member. Both the inline join flow and
+// the webhook (transition + reconciliation paths) can observe the same
+// activation, so dedupe on the membership id before inserting.
+export async function notifyNewMember(
+  publication: string | undefined,
+  membershipId: string,
+) {
+  if (!publication) return;
+  const recipient = new AtUri(publication).host;
+
+  const { data: existing, error: readError } = await supabaseServerClient
+    .from("notifications")
+    .select("id")
+    .eq("data->>type", "new_member")
+    .eq("data->>membership_id", membershipId)
+    .limit(1);
+  if (readError) throw readError;
+  if (existing && existing.length > 0) return;
+
+  const notification: Notification = {
+    id: v7(),
+    recipient,
+    data: { type: "new_member", publication, membership_id: membershipId },
+  };
+  const { error } = await supabaseServerClient
+    .from("notifications")
+    .insert(notification);
+  if (error) throw error;
+  await pingIdentityToUpdateNotification(recipient);
 }
 
 export async function pingIdentityToUpdateNotification(did: string) {


### PR DESCRIPTION
Before you pull, have you made sure...
- it looks good on both mobile and desktop — N/A, server-side changes only; the one UI-adjacent change (join page hides tiers without a provisioned monthly price) renders identically on both
- it undo's like it ought to — N/A, no editor/Replicache changes
- it handles keyboard interactions reasonably well — N/A
- no build errors!!! — `npx tsc` exits 0

---

Fixes for the correctness/billing findings from the paid-memberships review. Members-only content leakage (public PDS records, unauthenticated RPC endpoints) is intentionally **not** addressed here — that's being handled separately.

## Critical fixes

**Webhook can now heal untracked subscriptions.** The connect-events handler previously no-op'd when no membership row matched a subscription id (`if (!existing) return`), so any failure after `subscriptions.create` — a failed row upsert in `subscribeToTier`, or a row deleted later — left a live subscription billing the reader with no record, no access, and no way to cancel. The handler now falls through to a reconciliation path that re-fetches the live subscription from Stripe (event payloads are unordered snapshots) and rebuilds the row from the subscription's metadata, takes over a dead tracked row when this subscription is the live survivor, or logs loudly on genuine duplicate-billing collisions. Supabase read/write errors on webhook paths now throw so the route 500s and Stripe redelivers instead of ACKing lost writes.

**Duplicate live subscriptions from concurrent joins are swept.** Concurrent joins with different tier/cadence use different idempotency keys, so both `subscriptions.create` calls could succeed while only one row survives the `(publication, identity_id)` upsert. After the upsert, `subscribeToTier` now cancels older live membership subscriptions for the same reader+publication (ties break by id so racing requests can't cancel each other); the webhook reconciler converges the row onto the survivor.

**Identity merge no longer deletes membership state while Stripe keeps billing.** `mergeEmailIdentityIntoAtpIdentity` now migrates `publication_memberships`, `stripe_wallets`, `stripe_connected_customers`, and `stripe_connected_accounts` to the target identity instead of letting the `identities` FK cascade drop them. On a per-publication collision the active membership wins (target preferred on ties); dropped live rows are logged for manual cancellation.

**Platform webhook no longer 500-loops on wallet card collection.** Setup-mode Checkout sessions (membership card collection) complete on the platform account, and `handleCheckoutCompleted` threw on them for lack of a `client_reference_id`/subscription — putting every card save into Stripe's multi-day retry loop against the Leaflet Pro endpoint. Non-subscription-mode sessions are now ignored.

## Major fixes

- **Out-of-order events can't resurrect a canceled membership**: the tracked-row update path re-retrieves the subscription from Stripe before writing (`fresh` flag avoids a double fetch on the invoice path).
- **Tier price changes can't brick a tier**: new prices are created and persisted to the DB before replaced ones are archived (a leaked active price is harmless; a DB row pointing at an archived price blocked all new joins), and the same-amount short-circuit verifies the price is still active so re-saving repairs previously broken state.
- **Half-provisioned tiers are never offered**: new tier rows insert `active: false` until Stripe provisioning succeeds, and the join page also requires a monthly price id.
- **New-member notifications fire on the common inline join path**: previously only the webhook notified, and only on an inactive→active transition the inline flow always preempted. Notification creation is deduped by membership id across the inline flow and both webhook paths, via a shared `notifyNewMember` in `src/membership.server.ts` (deliberately not in the `"use server"` notifications module, where it would be a wire-callable action).
- **A lapsed-looking row can't cancel a live paid subscription**: before retiring a lingering subscription, `subscribeToTier` confirms with Stripe; if it's actually active (e.g. a missed renewal webhook), it refreshes the row and returns `already_member` instead of canceling a paid-up membership without refund.
- **`members_only` is recomputed after blob inflation** in `sync_document_metadata`, closing the gap where flag-keyed surfaces (publication post lists, `getPostsByUris`) served full gated content for blob-offloaded records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138kgpJVUG36MnMw1tdpmY3

---
_Generated by [Claude Code](https://claude.ai/code/session_0138kgpJVUG36MnMw1tdpmY3)_