### PR TITLE
Validate UUID format before querying database

### DIFF
--- a/app/(app)/[leaflet_id]/icon.tsx
+++ b/app/(app)/[leaflet_id]/icon.tsx
@@ -4,6 +4,7 @@ import type { Attribute } from "src/replicache/attributes";
 import { Database } from "supabase/database.types";
 import { createServerClient } from "@supabase/ssr";
 import { parseHSBToRGB } from "src/utils/parseHSB";
+import { isUuid } from "src/utils/isUuid";
 
 // Route segment config
 export const revalidate = 0;
@@ -27,14 +28,19 @@ let supabase = createServerClient<Database>(
 export default async function Icon(props: {
   params: Promise<{ leaflet_id: string }>;
 }) {
-  let res = await supabase
-    .from("permission_tokens")
-    .select("*, permission_token_rights(*)")
-    .eq("id", (await props.params).leaflet_id)
-    .single();
-  let rootEntity = res.data?.root_entity;
+  let leaflet_id = (await props.params).leaflet_id;
+  // Crawler paths land here as the route param; a non-uuid value makes
+  // Postgres throw 22P02, so skip the lookup and render the default icon.
+  let res = isUuid(leaflet_id)
+    ? await supabase
+        .from("permission_tokens")
+        .select("*, permission_token_rights(*)")
+        .eq("id", leaflet_id)
+        .single()
+    : null;
+  let rootEntity = res?.data?.root_entity;
   let outlineColor, fillColor;
-  if (rootEntity && res.data) {
+  if (rootEntity && res?.data) {
     let { data } = await supabase.rpc("get_facts", {
       root: rootEntity,
     });

--- a/app/(app)/[leaflet_id]/icon.tsx
+++ b/app/(app)/[leaflet_id]/icon.tsx
@@ -29,8 +29,6 @@ export default async function Icon(props: {
   params: Promise<{ leaflet_id: string }>;
 }) {
   let leaflet_id = (await props.params).leaflet_id;
-  // Crawler paths land here as the route param; a non-uuid value makes
-  // Postgres throw 22P02, so skip the lookup and render the default icon.
   let res = isUuid(leaflet_id)
     ? await supabase
         .from("permission_tokens")

--- a/app/(app)/[leaflet_id]/publish/page.tsx
+++ b/app/(app)/[leaflet_id]/publish/page.tsx
@@ -5,7 +5,7 @@ import { getIdentityData } from "actions/getIdentityData";
 
 import { AtpAgent } from "@atproto/api";
 import { ReplicacheProvider } from "src/replicache";
-import { isUuid, NIL_UUID } from "src/utils/isUuid";
+import { isUuid } from "src/utils/isUuid";
 
 export const preferredRegion = ["sfo1"];
 export const dynamic = "force-dynamic";
@@ -23,6 +23,7 @@ type Props = {
 };
 export default async function PublishLeafletPage(props: Props) {
   let leaflet_id = (await props.params).leaflet_id;
+  if (!isUuid(leaflet_id)) return null;
   let { data } = await supabaseServerClient
     .from("permission_tokens")
     .select(
@@ -41,9 +42,7 @@ export default async function PublishLeafletPage(props: Props) {
          documents(*)
        )`,
     )
-    // Guard against non-uuid route params (crawler paths), which make
-    // Postgres throw 22P02; the nil uuid reads as "no row" instead.
-    .eq("id", isUuid(leaflet_id) ? leaflet_id : NIL_UUID)
+    .eq("id", leaflet_id)
     .single();
   let rootEntity = data?.root_entity;
 

--- a/app/(app)/[leaflet_id]/publish/page.tsx
+++ b/app/(app)/[leaflet_id]/publish/page.tsx
@@ -5,6 +5,7 @@ import { getIdentityData } from "actions/getIdentityData";
 
 import { AtpAgent } from "@atproto/api";
 import { ReplicacheProvider } from "src/replicache";
+import { isUuid, NIL_UUID } from "src/utils/isUuid";
 
 export const preferredRegion = ["sfo1"];
 export const dynamic = "force-dynamic";
@@ -40,7 +41,9 @@ export default async function PublishLeafletPage(props: Props) {
          documents(*)
        )`,
     )
-    .eq("id", leaflet_id)
+    // Guard against non-uuid route params (crawler paths), which make
+    // Postgres throw 22P02; the nil uuid reads as "no row" instead.
+    .eq("id", isUuid(leaflet_id) ? leaflet_id : NIL_UUID)
     .single();
   let rootEntity = data?.root_entity;
 

--- a/app/api/ai/lib.tsx
+++ b/app/api/ai/lib.tsx
@@ -10,6 +10,7 @@ import { YJSFragmentToString } from "src/utils/yjsFragmentToString";
 import { Block } from "components/Blocks/Block";
 import { parseBlocksToList, List } from "src/utils/parseBlocksToList";
 import { htmlToMarkdown } from "src/htmlMarkdownParsers";
+import { isUuid } from "src/utils/isUuid";
 
 // --- Auth ---
 
@@ -35,7 +36,9 @@ export async function authenticateToken(
     return Response.json({ error: "Missing Authorization header" }, { status: 401 });
   }
   let tokenId = auth.slice("Bearer ".length).trim();
-  if (!tokenId) {
+  // Token ids are uuids; reject anything else before it reaches Postgres,
+  // which throws 22P02 on non-uuid input to a uuid column.
+  if (!tokenId || !isUuid(tokenId)) {
     return Response.json({ error: "Invalid token" }, { status: 401 });
   }
 

--- a/app/api/ai/lib.tsx
+++ b/app/api/ai/lib.tsx
@@ -36,8 +36,6 @@ export async function authenticateToken(
     return Response.json({ error: "Missing Authorization header" }, { status: 401 });
   }
   let tokenId = auth.slice("Bearer ".length).trim();
-  // Token ids are uuids; reject anything else before it reaches Postgres,
-  // which throws 22P02 on non-uuid input to a uuid column.
   if (!tokenId || !isUuid(tokenId)) {
     return Response.json({ error: "Invalid token" }, { status: 401 });
   }

--- a/app/api/rpc/[command]/get_leaflet_data.ts
+++ b/app/api/rpc/[command]/get_leaflet_data.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { makeRoute } from "../lib";
 import type { Env } from "./route";
+import { isUuid, NIL_UUID } from "src/utils/isUuid";
 
 export type GetLeafletDataReturnType = Awaited<
   ReturnType<(typeof get_leaflet_data)["handler"]>
@@ -28,7 +29,10 @@ export const get_leaflet_data = makeRoute({
         ${leaflets_to_documents_query},
         ${draft_publication_query}`,
       )
-      .eq("id", token_id)
+      // Crawler paths like /feed.xml reach the [leaflet_id] route and land
+      // here as token ids; guard so they read as "no row" instead of a
+      // Postgres 22P02 error.
+      .eq("id", isUuid(token_id) ? token_id : NIL_UUID)
       .single();
 
     type t = typeof res;

--- a/app/api/rpc/[command]/get_leaflet_data.ts
+++ b/app/api/rpc/[command]/get_leaflet_data.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { makeRoute } from "../lib";
 import type { Env } from "./route";
-import { isUuid, NIL_UUID } from "src/utils/isUuid";
+import { isUuid } from "src/utils/isUuid";
 
 export type GetLeafletDataReturnType = Awaited<
   ReturnType<(typeof get_leaflet_data)["handler"]>
@@ -19,6 +19,7 @@ export const get_leaflet_data = makeRoute({
   }),
 
   handler: async ({ token_id }, { supabase }: Pick<Env, "supabase">) => {
+    if (!isUuid(token_id)) return { result: { data: null, error: null } };
     let res = await supabase
       .from("permission_tokens")
       .select(
@@ -29,10 +30,7 @@ export const get_leaflet_data = makeRoute({
         ${leaflets_to_documents_query},
         ${draft_publication_query}`,
       )
-      // Crawler paths like /feed.xml reach the [leaflet_id] route and land
-      // here as token ids; guard so they read as "no row" instead of a
-      // Postgres 22P02 error.
-      .eq("id", isUuid(token_id) ? token_id : NIL_UUID)
+      .eq("id", token_id)
       .single();
 
     type t = typeof res;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import { cookies, headers } from "next/headers";
 import { supabaseServerClient } from "supabase/serverClient";
 import { isProductionDomain } from "./utils/isProductionDeployment";
+import { isUuid } from "./utils/isUuid";
 
 export const AUTH_TOKEN_COOKIE = "auth_token";
 // pending_merge_token carries a freshly-minted email_auth_token for the target
@@ -43,7 +44,7 @@ export async function removePendingMergeToken() {
 // Resolves a cookie-held email_auth_token id to the identity it authenticates.
 // Returns null unless the token is confirmed and the identity row exists.
 export async function resolveAuthToken(tokenId: string | undefined) {
-  if (!tokenId) return null;
+  if (!tokenId || !isUuid(tokenId)) return null;
   const { data } = await supabaseServerClient
     .from("email_auth_tokens")
     .select("id, confirmed, identities(id, email, atp_did)")

--- a/src/utils/isUuid.ts
+++ b/src/utils/isUuid.ts
@@ -1,0 +1,12 @@
+// Postgres throws 22P02 ("invalid input syntax for type uuid") when a
+// non-uuid string is compared against a uuid column, so validate untrusted
+// input (url segments, bearer tokens, cookies) before querying with it.
+// Matches no row (ids are generated randomly); substitute it for invalid
+// input when short-circuiting the query would complicate result typing.
+export const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
+export function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}

--- a/src/utils/isUuid.ts
+++ b/src/utils/isUuid.ts
@@ -1,10 +1,6 @@
 // Postgres throws 22P02 ("invalid input syntax for type uuid") when a
 // non-uuid string is compared against a uuid column, so validate untrusted
 // input (url segments, bearer tokens, cookies) before querying with it.
-// Matches no row (ids are generated randomly); substitute it for invalid
-// input when short-circuiting the query would complicate result typing.
-export const NIL_UUID = "00000000-0000-0000-0000-000000000000";
-
 export function isUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
     value,


### PR DESCRIPTION
## Description

Add UUID validation to prevent PostgreSQL errors when untrusted input (URL segments, bearer tokens, cookies) is queried against UUID columns. PostgreSQL throws error `22P02` ("invalid input syntax for type uuid") when a non-UUID string is compared to a UUID column, which can leak information and cause crashes.

## Changes

- **New utility**: `src/utils/isUuid.ts` — validates that a string matches the UUID v4 format using regex
- **Updated icon route**: `app/(app)/[leaflet_id]/icon.tsx` — validate `leaflet_id` before querying `permission_tokens`
- **Updated API auth**: `app/api/ai/lib.tsx` — validate bearer token format in `authenticateToken`
- **Updated auth resolver**: `src/auth.ts` — validate token ID before querying `email_auth_tokens`
- **Updated publish page**: `app/(app)/[leaflet_id]/publish/page.tsx` — validate `leaflet_id` early
- **Updated RPC handler**: `app/api/rpc/[command]/get_leaflet_data.ts` — validate `token_id` before querying

All validations follow the same pattern: check `isUuid()` before making database queries with untrusted input, returning early with safe defaults (null, error response) if validation fails.

## Testing

- Existing tests pass
- Manual verification: accessing routes/APIs with invalid UUID formats (e.g., `/abc123/icon`, bearer token `invalid-token`) now returns safe responses instead of database errors

https://claude.ai/code/session_01HskisMeSCeANwuLxQC8XuP