### PR TITLE
Show block controls on horizontal rule block

### DIFF
--- a/components/Blocks/HorizontalRule.tsx
+++ b/components/Blocks/HorizontalRule.tsx
@@ -1,15 +1,20 @@
 import { useUIState } from "src/useUIState";
-import { BlockProps } from "./Block";
+import { BlockLayout, BlockProps } from "./Block";
 
 export const HorizontalRule = (props: BlockProps) => {
   let isSelected = useUIState((s) =>
     s.selectedBlocks.find((b) => b.value === props.value),
   );
   return (
-    <hr
-      className={`my-2 w-full border-border-light
+    <BlockLayout
+      isSelected={!!isSelected}
+      className="border-transparent! outline-transparent! p-0! overflow-visible!"
+    >
+      <hr
+        className={`my-2 w-full border-border-light
     ${isSelected ? "block-border-selected outline-offset-[3px]!" : ""}
   `}
-    />
+      />
+    </BlockLayout>
   );
 };


### PR DESCRIPTION
Wrap the horizontal rule in BlockLayout so the standard non-text block
controls (move up/down, delete) appear when the block is selected, while
suppressing BlockLayout's border/outline/padding so the rule keeps its
existing appearance.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PcPUt1YeDB1BJMTSinAQdu