### PR TITLE
Implement domain cache with stale-while-revalidate pattern

### DIFF
--- a/actions/domains/index.ts
+++ b/actions/domains/index.ts
@@ -21,9 +21,6 @@ const VERCEL_TEAM = "team_42xaJiZMTw9Sr7i0DcLTae9d";
 // Shared helpers
 // ==============
 
-// The middleware caches domain -> routes lookups long-lived under this tag;
-// expire it after any assignment change so routing picks the change up
-// immediately.
 async function expireDomainCache(domain: string) {
   try {
     await getCache().expireTag(`domain:${domain}`);

--- a/actions/domains/index.ts
+++ b/actions/domains/index.ts
@@ -1,6 +1,7 @@
 "use server";
 import { Database } from "supabase/database.types";
 import { createServerClient } from "@supabase/ssr";
+import { getCache } from "@vercel/functions";
 import { Vercel } from "@vercel/sdk";
 import { getIdentityData } from "actions/getIdentityData";
 
@@ -19,6 +20,15 @@ const VERCEL_TEAM = "team_42xaJiZMTw9Sr7i0DcLTae9d";
 
 // Shared helpers
 // ==============
+
+// The middleware caches domain -> routes lookups long-lived under this tag;
+// expire it after any assignment change so routing picks the change up
+// immediately.
+async function expireDomainCache(domain: string) {
+  try {
+    await getCache().expireTag(`domain:${domain}`);
+  } catch {}
+}
 
 async function assertOwnsDomain(domain: string) {
   let identity = await getIdentityData();
@@ -125,6 +135,7 @@ export async function assignDomainToDocument({
     view_permission_token,
     edit_permission_token,
   });
+  await expireDomainCache(domain);
 
   return true;
 }
@@ -155,6 +166,7 @@ export async function assignDomainToPublication({
     identity: identity.atp_did,
     domain,
   });
+  await expireDomainCache(domain);
 
   return true;
 }
@@ -171,6 +183,7 @@ export async function removeDomainAssignment({
 }) {
   if (!(await assertOwnsDomain(domain))) return null;
   await clearAllAssignments(domain);
+  await expireDomainCache(domain);
   return true;
 }
 
@@ -182,9 +195,11 @@ export async function removeDomainRoute({ routeId }: { routeId: string }) {
   let allRoutes = identity.custom_domains.flatMap(
     (d) => d.custom_domain_routes,
   );
-  if (!allRoutes.find((r) => r.id === routeId)) return null;
+  let route = allRoutes.find((r) => r.id === routeId);
+  if (!route) return null;
 
   await supabase.from("custom_domain_routes").delete().eq("id", routeId);
+  await expireDomainCache(route.domain);
 
   return true;
 }
@@ -205,6 +220,7 @@ export async function deleteDomain({ domain }: { domain: string }) {
       domain,
     }),
   ]);
+  await expireDomainCache(domain);
 
   return true;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -42,6 +42,37 @@ async function getDomainRoutes(hostname: string) {
   return data;
 }
 type DomainRoutes = Awaited<ReturnType<typeof getDomainRoutes>>;
+type DomainCacheEntry = { routes: NonNullable<DomainRoutes>; cachedAt: number };
+
+// Entries live long and are expired by tag when a domain's assignment changes
+// (see expireDomainCache in actions/domains); cachedAt only bounds how long one
+// is served without a background re-check, as a net for out-of-band DB edits.
+const DOMAIN_CACHE_TTL_SECONDS = 60 * 60 * 24;
+const REVALIDATE_AFTER_MS = 60_000;
+
+// Coalesce concurrent lookups per hostname so a burst of requests hitting a
+// cache miss together produces one database query instead of one per request.
+let inflightLookups = new Map<string, Promise<DomainRoutes>>();
+function lookupDomainRoutes(hostname: string) {
+  let pending = inflightLookups.get(hostname);
+  if (!pending) {
+    pending = getDomainRoutes(hostname).finally(() =>
+      inflightLookups.delete(hostname),
+    );
+    inflightLookups.set(hostname, pending);
+  }
+  return pending;
+}
+
+async function persistDomainRoutes(hostname: string, routes: DomainRoutes) {
+  if (routes)
+    await cache.set(
+      `domain:${hostname}`,
+      { routes, cachedAt: Date.now() } satisfies DomainCacheEntry,
+      { ttl: DOMAIN_CACHE_TTL_SECONDS, tags: [`domain:${hostname}`] },
+    );
+  else await cache.delete(`domain:${hostname}`);
+}
 
 export default async function middleware(req: NextRequest) {
   let hostname = req.headers.get("host")!;
@@ -61,21 +92,25 @@ export default async function middleware(req: NextRequest) {
   if (hostname === "leaflet.pub") return;
   if (req.nextUrl.pathname === "/not-found") return;
   let routes: DomainRoutes = null;
+  let entry: DomainCacheEntry | null = null;
   try {
-    routes = (await cache.get(`domain:${hostname}`)) as DomainRoutes;
+    entry = (await cache.get(`domain:${hostname}`)) as DomainCacheEntry | null;
   } catch {}
-  if (!routes) {
-    routes = await getDomainRoutes(hostname);
-    if (routes) {
+  if (entry?.routes) {
+    // Serve the cached routes immediately and re-check stale entries in the
+    // background, so the database is never in the request path for a cached
+    // domain.
+    routes = entry.routes;
+    if (Date.now() - entry.cachedAt > REVALIDATE_AFTER_MS)
       waitUntil(
-        cache
-          .set(`domain:${hostname}`, routes, {
-            ttl: 60,
-            tags: [`domain:${hostname}`],
-          })
+        lookupDomainRoutes(hostname)
+          .then((fresh) => persistDomainRoutes(hostname, fresh))
           .catch(() => {}),
       );
-    }
+  } else {
+    routes = await lookupDomainRoutes(hostname);
+    if (routes)
+      waitUntil(persistDomainRoutes(hostname, routes).catch(() => {}));
   }
 
   let pub = routes?.publication_domains[0]?.publications;

--- a/middleware.ts
+++ b/middleware.ts
@@ -44,16 +44,11 @@ async function getDomainRoutes(hostname: string) {
 type DomainRoutes = Awaited<ReturnType<typeof getDomainRoutes>>;
 type DomainCacheEntry = { routes: NonNullable<DomainRoutes>; cachedAt: number };
 
-// Entries live long and are expired by tag when a domain's assignment changes
-// (see expireDomainCache in actions/domains); cachedAt only bounds how long one
-// is served without a background re-check, as a net for out-of-band DB edits.
 const DOMAIN_CACHE_TTL_SECONDS = 60 * 60 * 24;
 const REVALIDATE_AFTER_MS = 60_000;
 
-// Coalesce concurrent lookups per hostname so a burst of requests hitting a
-// cache miss together produces one database query instead of one per request.
 let inflightLookups = new Map<string, Promise<DomainRoutes>>();
-function lookupDomainRoutes(hostname: string) {
+function fetchDomainRoutesFromDB(hostname: string) {
   let pending = inflightLookups.get(hostname);
   if (!pending) {
     pending = getDomainRoutes(hostname).finally(() =>
@@ -64,7 +59,10 @@ function lookupDomainRoutes(hostname: string) {
   return pending;
 }
 
-async function persistDomainRoutes(hostname: string, routes: DomainRoutes) {
+async function writeDomainRoutesToCache(
+  hostname: string,
+  routes: DomainRoutes,
+) {
   if (routes)
     await cache.set(
       `domain:${hostname}`,
@@ -97,20 +95,17 @@ export default async function middleware(req: NextRequest) {
     entry = (await cache.get(`domain:${hostname}`)) as DomainCacheEntry | null;
   } catch {}
   if (entry?.routes) {
-    // Serve the cached routes immediately and re-check stale entries in the
-    // background, so the database is never in the request path for a cached
-    // domain.
     routes = entry.routes;
     if (Date.now() - entry.cachedAt > REVALIDATE_AFTER_MS)
       waitUntil(
-        lookupDomainRoutes(hostname)
-          .then((fresh) => persistDomainRoutes(hostname, fresh))
+        fetchDomainRoutesFromDB(hostname)
+          .then((fresh) => writeDomainRoutesToCache(hostname, fresh))
           .catch(() => {}),
       );
   } else {
-    routes = await lookupDomainRoutes(hostname);
+    routes = await fetchDomainRoutesFromDB(hostname);
     if (routes)
-      waitUntil(persistDomainRoutes(hostname, routes).catch(() => {}));
+      waitUntil(writeDomainRoutesToCache(hostname, routes).catch(() => {}));
   }
 
   let pub = routes?.publication_domains[0]?.publications;


### PR DESCRIPTION
## Description

Improves domain routing performance by implementing a multi-layered caching strategy with stale-while-revalidate semantics:

- **Long-lived cache**: Domain routes are cached for 24 hours with Vercel's cache API
- **Stale-while-revalidate**: Cached entries older than 1 minute are served immediately while a fresh lookup happens in the background
- **Request deduplication**: Concurrent lookups for the same domain are deduplicated to avoid redundant database queries
- **Cache invalidation**: Domain mutations (assignments, deletions, route changes) now explicitly expire the cache tag, ensuring fresh data is fetched on next request

### Changes

**middleware.ts**
- Added `DomainCacheEntry` type to store routes with timestamp
- Introduced `fetchDomainRoutesFromDB()` to deduplicate concurrent database lookups using an in-flight map
- Added `writeDomainRoutesToCache()` to handle both cache writes and deletes
- Updated middleware logic to:
  - Check cache first and serve stale entries while revalidating in background
  - Fall back to database if cache miss
  - Use `waitUntil()` for background revalidation to avoid blocking the response

**actions/domains/index.ts**
- Added `expireDomainCache()` helper to invalidate domain cache tags
- Call cache expiration after all domain mutations:
  - `assignDomainToDocument()`
  - `assignDomainToPublication()`
  - `removeDomainAssignment()`
  - `removeDomainRoute()`
  - `deleteDomain()`

## Checklist

- [x] No build errors
- [x] Cache invalidation is called on all domain mutations
- [x] Stale-while-revalidate logic prevents serving outdated routes while keeping responses fast

https://claude.ai/code/session_011cVr7WucTZKdyCbJXa3cPE