### PR TITLE
Snap image-resize dimensions to a fixed width ladder

### DIFF
--- a/app/api/atproto_images/route.ts
+++ b/app/api/atproto_images/route.ts
@@ -4,6 +4,7 @@ import { IdResolver } from "@atproto/identity";
 import { NextRequest, NextResponse } from "next/server";
 import sharp from "sharp";
 import { supabaseServerClient } from "supabase/serverClient";
+import { snapToImageWidth } from "supabase/imageSizes";
 
 let idResolver = new IdResolver();
 
@@ -48,9 +49,7 @@ function parseDimension(value: string | null): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
-  // Clamp to a sane upper bound so the proxy can't be used to request
-  // arbitrarily large transforms.
-  return Math.min(parsed, 2000);
+  return snapToImageWidth(parsed);
 }
 
 function publicUrl(path: string) {

--- a/app/api/resized_images/route.ts
+++ b/app/api/resized_images/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import sharp from "sharp";
 import { supabaseServerClient } from "supabase/serverClient";
+import { snapToImageWidth } from "supabase/imageSizes";
 
 // Downscaling for storage images, used by the next/image loader
 // (supabase/supabase-image-loader.js). Resizing here with sharp instead of
@@ -24,9 +25,7 @@ function parseDimension(value: string | null): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
-  // Clamp to a sane upper bound so the proxy can't be used to request
-  // arbitrarily large resizes.
-  return Math.min(parsed, 2000);
+  return snapToImageWidth(parsed);
 }
 
 function publicUrl(bucketAndPath: string) {

--- a/components/Interactions/InteractionShareButton.tsx
+++ b/components/Interactions/InteractionShareButton.tsx
@@ -218,7 +218,7 @@ export const BskyShareModal = (props: {
   let coverThumb =
     coverImage && authorDid
       ? blobRefToSrc(coverImage.ref, authorDid, undefined, {
-          width: 1000,
+          width: 1200,
         })
       : undefined;
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const { IMAGE_WIDTHS } = require("./supabase/imageSizes");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   turbopack: {
@@ -26,6 +28,8 @@ const nextConfig = {
   images: {
     loader: "custom",
     loaderFile: "./supabase/supabase-image-loader.js",
+    deviceSizes: IMAGE_WIDTHS,
+    imageSizes: [],
     remotePatterns: [
       { protocol: "http", hostname: "127.0.0.1", port: "54321" },
       { protocol: "https", hostname: "bdefzwcumgzjwllsnaej.supabase.co" },

--- a/supabase/imageSizes.js
+++ b/supabase/imageSizes.js
@@ -1,0 +1,20 @@
+// The only output widths the image-resizing proxies will produce. Off-ladder
+// requests are snapped up to the nearest entry (and capped at the largest)
+// rather than rejected: dimensions are caller-controlled and each distinct
+// value mints a permanent stored variant, so without snapping an
+// unauthenticated caller could fill storage with thousands of variants per
+// image — while rejecting would break URLs already living in edge and browser
+// caches. 360/800 are the app's cover-thumbnail widths (COVER_THUMBNAIL_WIDTH),
+// 1200 covers document-body images at retina density (~600px column × 2), and
+// 2000 is the existing hard cap for full-size use.
+const IMAGE_WIDTHS = [360, 800, 1200, 2000];
+
+/** @param {number} width */
+function snapToImageWidth(width) {
+  return (
+    IMAGE_WIDTHS.find((w) => w >= width) ??
+    IMAGE_WIDTHS[IMAGE_WIDTHS.length - 1]
+  );
+}
+
+module.exports = { IMAGE_WIDTHS, snapToImageWidth };

--- a/supabase/supabase-image-loader.js
+++ b/supabase/supabase-image-loader.js
@@ -1,8 +1,10 @@
+import { snapToImageWidth } from "./imageSizes";
+
 export default function supabaseLoader({ src, width, quality }) {
   const path = src.startsWith("/") ? src.slice(1) : src;
   // Resize through our own sharp-backed proxy rather than Supabase's
   // render/image endpoint, which bills every distinct origin image
   // transformed each month. The proxy scales proportionally to `width` and
   // never upscales, matching the previous resize=contain behavior (see #286).
-  return `/api/resized_images?path=${encodeURIComponent(path)}&width=${width}`;
+  return `/api/resized_images?path=${encodeURIComponent(path)}&width=${snapToImageWidth(width)}`;
 }


### PR DESCRIPTION
The resized_images and atproto_images routes accept caller-controlled dimensions, and every novel value mints a permanent stored variant on cache miss — an unauthenticated caller could mint ~2000 objects per image (~4M per cid for w×h) just by walking the width space. Snap requests to a 4-entry ladder shared from supabase/imageSizes.js so the keyspace per image is bounded: 360/800 are the app's own cover-thumbnail widths, 1200 covers document-body images at retina density, 2000 is the existing cap. Snapping up (never rejecting) keeps URLs already living in edge and browser caches working across the deploy, and off-ladder requests collapse onto the same stored objects because the snapped value keys both the sharp resize and the variant path. atproto_images height is snapped too rather than dropped, keeping old cached URLs valid while bounding the w×h grid.

Align the clients so real traffic is on-ladder before it reaches the edge cache: the next/image loader snaps in the browser, and images.deviceSizes is set to the ladder (imageSizes emptied — its entries must sit below the smallest deviceSize and every icon-sized use already collapses to 360 via the loader) so srcset candidates come out of the same four widths instead of Next's 16-entry default. The share composer's 1000px cover prefetch moves to the 1200 rung it would be snapped to anyway.


Claude-Session: https://claude.ai/code/session_01MQBgS6Lb1BrTgg2pu1Bfm4

Before you pull, have you made sure...
- it looks good on both mobile and desktop
- it undo's like it ought to
- it handles keyboard interactions reasonably well
- no build errors!!!
