### PR TITLE
Extract AT Protocol image caching to shared utility

### DIFF
--- a/actions/publications/subscribeEmail.tsx
+++ b/actions/publications/subscribeEmail.tsx
@@ -65,12 +65,14 @@ export async function requestPublicationEmailSubscription(
   const normalizedPub = normalizePublicationRecord(publication?.record);
   const pubName = normalizedPub?.name;
   const pubUrl = normalizedPub?.url;
-  const assetsBaseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
+  const assetsBaseUrl =
+    process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
   const pubIcon = normalizedPub?.icon
     ? blobRefToSrc(
         normalizedPub.icon.ref,
         new AtUri(publicationUri).host,
         assetsBaseUrl,
+        { width: 360 },
       )
     : undefined;
 
@@ -356,4 +358,3 @@ async function linkEmailToCurrentIdentity(
   if (!merged.ok) return Err("database_error");
   return Ok(current.id);
 }
-

--- a/app/(app)/(home-pages)/p/[didOrHandle]/ProfileHeader.tsx
+++ b/app/(app)/(home-pages)/p/[didOrHandle]/ProfileHeader.tsx
@@ -129,7 +129,9 @@ const PublicationCard = (props: {
         <PubIcon
           icon={
             record.icon
-              ? blobRefToSrc(record.icon.ref, new AtUri(uri).host)
+              ? blobRefToSrc(record.icon.ref, new AtUri(uri).host, undefined, {
+                  width: 360,
+                })
               : undefined
           }
           pubName={record.name}

--- a/app/(app)/(home-pages)/p/[didOrHandle]/PubListing.tsx
+++ b/app/(app)/(home-pages)/p/[didOrHandle]/PubListing.tsx
@@ -28,6 +28,8 @@ export const PubListing = (props: PubListingProps) => {
     ? blobRefToSrc(
         record?.theme?.backgroundImage?.image?.ref,
         new AtUri(props.uri).host,
+        undefined,
+        { width: 2000 },
       )
     : null;
 
@@ -58,7 +60,12 @@ export const PubListing = (props: PubListingProps) => {
             <PubIcon
               icon={
                 record.icon
-                  ? blobRefToSrc(record.icon.ref, new AtUri(props.uri).host)
+                  ? blobRefToSrc(
+                      record.icon.ref,
+                      new AtUri(props.uri).host,
+                      undefined,
+                      { width: 360 },
+                    )
                   : undefined
               }
               pubName={record.name}

--- a/app/(app)/[leaflet_id]/actions/PublishButton.tsx
+++ b/app/(app)/[leaflet_id]/actions/PublishButton.tsx
@@ -429,6 +429,8 @@ const PubSelector = (props: {
                         ? blobRefToSrc(
                             pubRecord.icon.ref,
                             new AtUri(p.uri).host,
+                            undefined,
+                            { width: 360 },
                           )
                         : undefined
                     }

--- a/app/(app)/[leaflet_id]/publish/PublishPost.tsx
+++ b/app/(app)/[leaflet_id]/publish/PublishPost.tsx
@@ -301,7 +301,12 @@ const PublishPostForm = (
                         title: props.pubRecord?.name,
                         icon:
                           props.pubRecord?.icon && pubDid
-                            ? blobRefToSrc(props.pubRecord.icon.ref, pubDid)
+                            ? blobRefToSrc(
+                                props.pubRecord.icon.ref,
+                                pubDid,
+                                undefined,
+                                { width: 360 },
+                              )
                             : undefined,
                       },
 
@@ -562,6 +567,8 @@ const PublishingTo = (props: {
                 ? blobRefToSrc(
                     props.record.icon.ref,
                     new AtUri(props.publication_uri).host,
+                    undefined,
+                    { width: 360 },
                   )
                 : undefined
             }

--- a/app/(app)/[leaflet_id]/publish/ShareOptions.tsx
+++ b/app/(app)/[leaflet_id]/publish/ShareOptions.tsx
@@ -58,7 +58,14 @@ export function ShareOptions(props: Props) {
         title: props.pubRecord?.name,
         icon:
           props.pubRecord?.icon && ownerProfile.did
-            ? blobRefToSrc(props.pubRecord.icon.ref, ownerProfile.did)
+            ? blobRefToSrc(
+                props.pubRecord.icon.ref,
+                ownerProfile.did,
+                undefined,
+                {
+                  width: 360,
+                },
+              )
             : undefined,
       },
 

--- a/app/(app)/lish/[did]/[publication]/DefaultPublicationHomepage.tsx
+++ b/app/(app)/lish/[did]/[publication]/DefaultPublicationHomepage.tsx
@@ -65,8 +65,8 @@ export const DefaultPublicationHomepage = ({
   const navPages = publishedNavPages(publication.publication_pages);
   const posts: PublicationPostsListPost[] = fakePosts
     ? []
-    : (resolvedPosts ??
-      buildPublicationPosts(publication.documents_in_publications));
+    : resolvedPosts ??
+      buildPublicationPosts(publication.documents_in_publications);
   return (
     <>
       <FontLoader
@@ -75,7 +75,11 @@ export const DefaultPublicationHomepage = ({
       />
       <PublicationHomeLayout
         showPageBackground={!!showPageBackground}
-        iconUrl={record?.icon ? blobRefToSrc(record.icon.ref, did) : undefined}
+        iconUrl={
+          record?.icon
+            ? blobRefToSrc(record.icon.ref, did, undefined, { width: 360 })
+            : undefined
+        }
         wordmark={wordmarkFromTheme(record?.theme, did)}
         navPages={navPages}
         publicationUrl={getPublicationURL(publication)}

--- a/app/(app)/lish/[did]/[publication]/[rkey]/Blocks/PublishedImageGallery.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/Blocks/PublishedImageGallery.tsx
@@ -24,8 +24,8 @@ export function PublishedImageGallery(props: {
   did: string;
 }) {
   let { block, did } = props;
-  // Grid/strip/carousel cells render well under 800px, so they get a resized
-  // variant; the lightbox gets the full-resolution blob.
+  // Grid/strip/carousel cells get the 1200 tier (document-body column at
+  // retina density); the lightbox gets the full-resolution blob.
   let { images, fullImages } = useMemo(() => {
     let toImage = (
       i: PubLeafletBlocksImageGallery.Image,
@@ -37,7 +37,7 @@ export function PublishedImageGallery(props: {
       height: i.aspectRatio.height,
     });
     return {
-      images: block.images.map((i) => toImage(i, { width: 800 })),
+      images: block.images.map((i) => toImage(i, { width: 1200 })),
       fullImages: block.images.map((i) => toImage(i)),
     };
   }, [block.images, did]);

--- a/app/(app)/lish/[did]/[publication]/[rkey]/Blocks/PublishedImageGallery.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/Blocks/PublishedImageGallery.tsx
@@ -24,16 +24,23 @@ export function PublishedImageGallery(props: {
   did: string;
 }) {
   let { block, did } = props;
-  let images = useMemo<GalleryImage[]>(
-    () =>
-      block.images.map((i) => ({
-        src: blobRefToSrc(i.image.ref, did),
-        alt: i.alt || "",
-        width: i.aspectRatio.width,
-        height: i.aspectRatio.height,
-      })),
-    [block.images, did],
-  );
+  // Grid/strip/carousel cells render well under 800px, so they get a resized
+  // variant; the lightbox gets the full-resolution blob.
+  let { images, fullImages } = useMemo(() => {
+    let toImage = (
+      i: PubLeafletBlocksImageGallery.Image,
+      transform?: { width: number },
+    ): GalleryImage => ({
+      src: blobRefToSrc(i.image.ref, did, undefined, transform),
+      alt: i.alt || "",
+      width: i.aspectRatio.width,
+      height: i.aspectRatio.height,
+    });
+    return {
+      images: block.images.map((i) => toImage(i, { width: 800 })),
+      fullImages: block.images.map((i) => toImage(i)),
+    };
+  }, [block.images, did]);
 
   let [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   let openLightbox = (index: number) => setLightboxIndex(index);
@@ -76,7 +83,7 @@ export function PublishedImageGallery(props: {
         count={images.length}
         index={lightboxIndex}
         onIndexChange={setLightboxIndex}
-        renderSlide={(i) => <LightboxSlide image={images[i]} />}
+        renderSlide={(i) => <LightboxSlide image={fullImages[i]} />}
       />
     </div>
   );

--- a/app/(app)/lish/[did]/[publication]/[rkey]/Blocks/PublishedImageGallery.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/Blocks/PublishedImageGallery.tsx
@@ -19,28 +19,31 @@ import {
   LightboxSlide,
 } from "components/Blocks/ImageGalleryBlock/ImageGalleryLightbox";
 
+function toImage(
+  i: PubLeafletBlocksImageGallery.Image,
+  did: string,
+  transform?: Parameters<typeof blobRefToSrc>[3],
+): GalleryImage {
+  return {
+    src: blobRefToSrc(i.image.ref, did, undefined, transform),
+    alt: i.alt || "",
+    width: i.aspectRatio.width,
+    height: i.aspectRatio.height,
+  };
+}
+
 export function PublishedImageGallery(props: {
   block: PubLeafletBlocksImageGallery.Main;
   did: string;
 }) {
   let { block, did } = props;
   // Grid/strip/carousel cells get the 1200 tier (document-body column at
-  // retina density); the lightbox gets the full-resolution blob.
-  let { images, fullImages } = useMemo(() => {
-    let toImage = (
-      i: PubLeafletBlocksImageGallery.Image,
-      transform?: { width: number },
-    ): GalleryImage => ({
-      src: blobRefToSrc(i.image.ref, did, undefined, transform),
-      alt: i.alt || "",
-      width: i.aspectRatio.width,
-      height: i.aspectRatio.height,
-    });
-    return {
-      images: block.images.map((i) => toImage(i, { width: 1200 })),
-      fullImages: block.images.map((i) => toImage(i)),
-    };
-  }, [block.images, did]);
+  // retina density); the lightbox gets the full-resolution blob, built
+  // per-slide only when it's actually opened.
+  let images = useMemo<GalleryImage[]>(
+    () => block.images.map((i) => toImage(i, did, { width: 1200 })),
+    [block.images, did],
+  );
 
   let [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   let openLightbox = (index: number) => setLightboxIndex(index);
@@ -83,7 +86,9 @@ export function PublishedImageGallery(props: {
         count={images.length}
         index={lightboxIndex}
         onIndexChange={setLightboxIndex}
-        renderSlide={(i) => <LightboxSlide image={fullImages[i]} />}
+        renderSlide={(i) => (
+          <LightboxSlide image={toImage(block.images[i], did)} />
+        )}
       />
     </div>
   );

--- a/app/(app)/lish/[did]/[publication]/[rkey]/PostContent.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/PostContent.tsx
@@ -472,7 +472,7 @@ export let Block = ({
             <div
               className={`imagePreview w-[120px] m-2 -mb-2 bg-cover shrink-0 rounded-t-md border border-border rotate-[4deg] origin-center relative`}
               style={{
-                backgroundImage: `url(${blobRefToSrc(b.block.previewImage?.ref, did)})`,
+                backgroundImage: `url(${blobRefToSrc(b.block.previewImage?.ref, did, undefined, { width: 360 })})`,
                 backgroundPosition: "center",
               }}
             />
@@ -516,7 +516,9 @@ export let Block = ({
                 height={b.block.aspectRatio?.height}
                 width={b.block.aspectRatio?.width}
                 className={`${isFullBleed ? "w-full border-none" : "rounded-lg border border-transparent "}  ${className}`}
-                src={blobRefToSrc(b.block.image.ref, did)}
+                src={blobRefToSrc(b.block.image.ref, did, undefined, {
+                  width: 2000,
+                })}
               />
             </button>
             {b.block.alt && <ReadOnlyAltText alt={b.block.alt} />}

--- a/app/(app)/lish/[did]/[publication]/[rkey]/PublicationPageRenderer.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/PublicationPageRenderer.tsx
@@ -132,10 +132,7 @@ export async function PublicationPageRenderer({
         firstBatch,
         await getProfiles(bylineDidsForPosts(firstBatch)),
       );
-      return [
-        key,
-        { uris: ordered.map((p) => p.uri), initialPosts },
-      ] as const;
+      return [key, { uris: ordered.map((p) => p.uri), initialPosts }] as const;
     }),
   );
 
@@ -201,7 +198,14 @@ export async function PublicationPageRenderer({
               pageWidth={normalizedPublication?.theme?.pageWidth}
               iconUrl={
                 normalizedPublication?.icon
-                  ? blobRefToSrc(normalizedPublication.icon.ref, did)
+                  ? blobRefToSrc(
+                      normalizedPublication.icon.ref,
+                      did,
+                      undefined,
+                      {
+                        width: 360,
+                      },
+                    )
                   : undefined
               }
               wordmark={wordmarkFromTheme(normalizedPublication?.theme, did)}

--- a/app/(app)/lish/[did]/[publication]/[rkey]/StaticPostContent.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/StaticPostContent.tsx
@@ -123,7 +123,7 @@ let Block = async ({
           alt={b.block.alt}
           height={b.block.aspectRatio?.height}
           width={b.block.aspectRatio?.width}
-          src={blobRefToSrc(b.block.image.ref, did, baseUrl, { width: 800 })}
+          src={blobRefToSrc(b.block.image.ref, did, baseUrl, { width: 1200 })}
         />
       );
     }
@@ -141,7 +141,7 @@ let Block = async ({
               alt={image.alt}
               height={image.aspectRatio.height}
               width={image.aspectRatio.width}
-              src={blobRefToSrc(image.image.ref, did, baseUrl, { width: 800 })}
+              src={blobRefToSrc(image.image.ref, did, baseUrl, { width: 1200 })}
             />
           ))}
         </div>

--- a/app/(app)/lish/[did]/[publication]/[rkey]/StaticPostContent.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/StaticPostContent.tsx
@@ -109,7 +109,7 @@ let Block = async ({
             <div
               className={`imagePreview w-[120px] m-2 -mb-2 bg-cover shrink-0 rounded-t-md border border-border rotate-[4deg] origin-center relative`}
               style={{
-                backgroundImage: `url(${blobRefToSrc(b.block.previewImage?.ref, did, baseUrl)})`,
+                backgroundImage: `url(${blobRefToSrc(b.block.previewImage?.ref, did, baseUrl, { width: 360 })})`,
                 backgroundPosition: "center",
               }}
             />
@@ -123,7 +123,7 @@ let Block = async ({
           alt={b.block.alt}
           height={b.block.aspectRatio?.height}
           width={b.block.aspectRatio?.width}
-          src={blobRefToSrc(b.block.image.ref, did, baseUrl)}
+          src={blobRefToSrc(b.block.image.ref, did, baseUrl, { width: 800 })}
         />
       );
     }
@@ -141,7 +141,7 @@ let Block = async ({
               alt={image.alt}
               height={image.aspectRatio.height}
               width={image.aspectRatio.width}
-              src={blobRefToSrc(image.image.ref, did, baseUrl)}
+              src={blobRefToSrc(image.image.ref, did, baseUrl, { width: 800 })}
             />
           ))}
         </div>
@@ -202,7 +202,9 @@ function ListItem(props: {
         className={`listMarker shrink-0 mx-2 z-1 mt-[14px] h-[5px] w-[5px] rounded-full bg-secondary`}
       />
       {isChecklist && (
-        <div className={`pr-2 ${props.item.checked ? "text-accent-contrast" : "text-border"}`}>
+        <div
+          className={`pr-2 ${props.item.checked ? "text-accent-contrast" : "text-border"}`}
+        >
           {props.item.checked ? <CheckboxChecked /> : <CheckboxEmpty />}
         </div>
       )}

--- a/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
@@ -1,8 +1,8 @@
 import { ogScreenshotResponse } from "src/utils/screenshotPage";
 import { supabaseServerClient } from "supabase/serverClient";
 import { jsonToLex } from "@atproto/lexicon";
-import { fetchAtprotoBlob } from "app/api/atproto_images/route";
 import { normalizeDocumentRecord } from "src/utils/normalizeRecords";
+import { coverImageRedirect } from "src/utils/ogCoverImageRedirect";
 import { resolveDocumentFilter } from "../resolveDocumentFilter";
 
 // OG content is effectively immutable post-publish, and each regeneration is a
@@ -30,28 +30,11 @@ export default async function OpenGraphImage(props: {
   if (document) {
     const docRecord = normalizeDocumentRecord(jsonToLex(document.data));
     if (docRecord?.coverImage) {
-      try {
-        // Get CID from the blob ref (handle both serialized and hydrated forms)
-        let cid =
-          (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
-          docRecord.coverImage.ref.toString();
-
-        let imageResponse = await fetchAtprotoBlob(did, cid);
-        if (imageResponse) {
-          let imageBlob = await imageResponse.blob();
-
-          // Return the image with appropriate headers
-          return new Response(imageBlob, {
-            headers: {
-              "Content-Type": imageBlob.type || "image/jpeg",
-              "Cache-Control": "public, max-age=3600",
-            },
-          });
-        }
-      } catch (e) {
-        // Fall through to screenshot if cover image fetch fails
-        console.error("Failed to fetch cover image:", e);
-      }
+      // Get CID from the blob ref (handle both serialized and hydrated forms)
+      let cid =
+        (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
+        docRecord.coverImage.ref.toString();
+      return coverImageRedirect(did, cid);
     }
   }
 

--- a/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
@@ -34,7 +34,9 @@ export default async function OpenGraphImage(props: {
       let cid =
         (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
         docRecord.coverImage.ref.toString();
-      return coverImageRedirect(did, cid);
+      let res = await coverImageRedirect(did, cid);
+      if (res) return res;
+      // Fall through to screenshot if the cover couldn't be cached
     }
   }
 

--- a/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts
@@ -30,11 +30,7 @@ export default async function OpenGraphImage(props: {
   if (document) {
     const docRecord = normalizeDocumentRecord(jsonToLex(document.data));
     if (docRecord?.coverImage) {
-      // Get CID from the blob ref (handle both serialized and hydrated forms)
-      let cid =
-        (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
-        docRecord.coverImage.ref.toString();
-      let res = await coverImageRedirect(did, cid);
+      let res = await coverImageRedirect(did, docRecord.coverImage.ref);
       if (res) return res;
       // Fall through to screenshot if the cover couldn't be cached
     }

--- a/app/(app)/lish/[did]/[publication]/archive/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/archive/page.tsx
@@ -125,7 +125,11 @@ export default async function PublicationArchive(props: {
         />
         <PublicationHomeLayout
           showPageBackground={!!record?.theme?.showPageBackground}
-          iconUrl={record?.icon ? blobRefToSrc(record.icon.ref, did) : undefined}
+          iconUrl={
+            record?.icon
+              ? blobRefToSrc(record.icon.ref, did, undefined, { width: 360 })
+              : undefined
+          }
           wordmark={wordmarkFromTheme(record?.theme, did)}
           navPages={publishedNavPages(publication.publication_pages)}
           publicationUrl={getPublicationURL(publication)}

--- a/app/(app)/lish/[did]/[publication]/dashboard/settings/SettingsContent.tsx
+++ b/app/(app)/lish/[did]/[publication]/dashboard/settings/SettingsContent.tsx
@@ -23,6 +23,7 @@ import {
   useCanSeePayments,
 } from "src/hooks/useEntitlement";
 import { useIdentityData } from "components/IdentityProvider";
+import { blobRefToSrc } from "src/utils/blobRefToSrc";
 import { InlineUpgradeToPro, UpgradeToProButton } from "../../UpgradeModal";
 import { Modal } from "components/Modal";
 import { Input } from "components/Input";
@@ -93,7 +94,9 @@ export function SettingsContent(props: { showPageBackground: boolean }) {
     setDescriptionValue(record.description || "");
     if (record.icon)
       setIconPreview(
-        `/api/atproto_images?did=${pubData.identity_did}&cid=${(record.icon.ref as unknown as { $link: string })["$link"]}`,
+        blobRefToSrc(record.icon.ref, pubData.identity_did, undefined, {
+          width: 360,
+        }),
       );
   }, [pubData, record]);
 

--- a/app/(app)/lish/[did]/[publication]/edit/PublicationDraftEditor.tsx
+++ b/app/(app)/lish/[did]/[publication]/edit/PublicationDraftEditor.tsx
@@ -33,7 +33,7 @@ export function PublicationDraftEditor(props: {
 }) {
   let record = props.publicationRecord;
   const iconUrl = record?.icon
-    ? blobRefToSrc(record.icon.ref, props.did)
+    ? blobRefToSrc(record.icon.ref, props.did, undefined, { width: 360 })
     : undefined;
 
   if (!record) return;

--- a/app/(app)/lish/[did]/[publication]/icon/route.ts
+++ b/app/(app)/lish/[did]/[publication]/icon/route.ts
@@ -3,33 +3,21 @@ import { supabaseServerClient } from "supabase/serverClient";
 import sharp from "sharp";
 import { normalizePublicationRecord } from "src/utils/normalizeRecords";
 import { publicationNameOrUriFilter } from "src/utils/uriHelpers";
-import { fetchAtprotoBlob } from "app/api/atproto_images/route";
+import {
+  ensureDerivedImageCached,
+  fetchAtprotoBlob,
+} from "src/utils/atprotoImages";
 
 export const dynamic = "force-dynamic";
 
 // Favicon variants are keyed by CID, so they're immutable; the redirect
 // response itself stays short-lived since the record's icon can change.
-const ICON_BUCKET = "url-previews";
 const ICON_PREFIX = "pub-icon/w32";
 const CACHE_HEADERS = {
   "CDN-Cache-Control": "s-maxage=86400, stale-while-revalidate=86400",
   "Cache-Control":
     "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400",
 };
-
-function variantUrl(cid: string) {
-  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/object/public/${ICON_BUCKET}/${ICON_PREFIX}/${cid}`;
-}
-
-// Bytes are served off Supabase's CDN rather than streamed through this
-// function: bytes leaving Vercel bill at fast data transfer rates while
-// Supabase serves the same bytes as cheap cached egress.
-function redirect(to: string) {
-  return new NextResponse(null, {
-    status: 302,
-    headers: { Location: to, ...CACHE_HEADERS },
-  });
-}
 
 export async function GET(
   request: NextRequest,
@@ -59,31 +47,31 @@ export async function GET(
 
     let cid = (record.icon.ref as unknown as { $link: string })["$link"];
 
-    // Already resized and stored for this CID?
-    const existing = await fetch(variantUrl(cid), { method: "HEAD" });
-    if (existing.ok) return redirect(variantUrl(cid));
-
-    const response = await fetchAtprotoBlob(did, cid);
-    if (!response)
-      return NextResponse.redirect(new URL("/icon.png", request.url));
-    let resizedImage = await sharp(await response.arrayBuffer())
-      .resize({ width: 32, height: 32 })
-      .png()
-      .toBuffer();
-
-    const { error } = await supabaseServerClient.storage
-      .from(ICON_BUCKET)
-      .upload(`${ICON_PREFIX}/${cid}`, new Uint8Array(resizedImage), {
-        contentType: "image/png",
-        // storage-js expects seconds, not a header value.
-        cacheControl: "31536000",
-        upsert: true,
+    let resized: Uint8Array | null = null;
+    const url = await ensureDerivedImageCached(
+      `${ICON_PREFIX}/${cid}`,
+      async () => {
+        const response = await fetchAtprotoBlob(did, cid);
+        if (!response) return null;
+        resized = new Uint8Array(
+          await sharp(await response.arrayBuffer())
+            .resize({ width: 32, height: 32 })
+            .png()
+            .toBuffer(),
+        );
+        return { bytes: resized, contentType: "image/png" };
+      },
+    );
+    if (url)
+      return new NextResponse(null, {
+        status: 302,
+        headers: { Location: url, ...CACHE_HEADERS },
       });
-    if (!error) return redirect(variantUrl(cid));
-    console.log("failed to store favicon variant", cid, error);
+    if (!resized)
+      return NextResponse.redirect(new URL("/icon.png", request.url));
 
     // Fall back to streaming the resized bytes if storage failed.
-    return new Response(new Uint8Array(resizedImage), {
+    return new Response(resized, {
       headers: {
         "Content-Type": "image/png",
         ...CACHE_HEADERS,

--- a/app/(app)/lish/[did]/[publication]/icon/route.ts
+++ b/app/(app)/lish/[did]/[publication]/icon/route.ts
@@ -1,13 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
-import { IdResolver } from "@atproto/identity";
 import { supabaseServerClient } from "supabase/serverClient";
 import sharp from "sharp";
 import { normalizePublicationRecord } from "src/utils/normalizeRecords";
 import { publicationNameOrUriFilter } from "src/utils/uriHelpers";
-
-let idResolver = new IdResolver();
+import { fetchAtprotoBlob } from "app/api/atproto_images/route";
 
 export const dynamic = "force-dynamic";
+
+// Favicon variants are keyed by CID, so they're immutable; the redirect
+// response itself stays short-lived since the record's icon can change.
+const ICON_BUCKET = "url-previews";
+const ICON_PREFIX = "pub-icon/w32";
+const CACHE_HEADERS = {
+  "CDN-Cache-Control": "s-maxage=86400, stale-while-revalidate=86400",
+  "Cache-Control":
+    "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400",
+};
+
+function variantUrl(cid: string) {
+  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/object/public/${ICON_BUCKET}/${ICON_PREFIX}/${cid}`;
+}
+
+// Bytes are served off Supabase's CDN rather than streamed through this
+// function: bytes leaving Vercel bill at fast data transfer rates while
+// Supabase serves the same bytes as cheap cached egress.
+function redirect(to: string) {
+  return new NextResponse(null, {
+    status: 302,
+    headers: { Location: to, ...CACHE_HEADERS },
+  });
+}
 
 export async function GET(
   request: NextRequest,
@@ -35,24 +57,36 @@ export async function GET(
     if (!record?.icon)
       return NextResponse.redirect(new URL("/icon.png", request.url));
 
-    let identity = await idResolver.did.resolve(did);
-    let service = identity?.service?.find((f) => f.id === "#atproto_pds");
-    if (!service)
-      return NextResponse.redirect(new URL("/icon.png", request.url));
     let cid = (record.icon.ref as unknown as { $link: string })["$link"];
-    const response = await fetch(
-      `${service.serviceEndpoint}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${cid}`,
-    );
-    let blob = await response.blob();
-    let resizedImage = await sharp(await blob.arrayBuffer())
+
+    // Already resized and stored for this CID?
+    const existing = await fetch(variantUrl(cid), { method: "HEAD" });
+    if (existing.ok) return redirect(variantUrl(cid));
+
+    const response = await fetchAtprotoBlob(did, cid);
+    if (!response)
+      return NextResponse.redirect(new URL("/icon.png", request.url));
+    let resizedImage = await sharp(await response.arrayBuffer())
       .resize({ width: 32, height: 32 })
+      .png()
       .toBuffer();
+
+    const { error } = await supabaseServerClient.storage
+      .from(ICON_BUCKET)
+      .upload(`${ICON_PREFIX}/${cid}`, new Uint8Array(resizedImage), {
+        contentType: "image/png",
+        // storage-js expects seconds, not a header value.
+        cacheControl: "31536000",
+        upsert: true,
+      });
+    if (!error) return redirect(variantUrl(cid));
+    console.log("failed to store favicon variant", cid, error);
+
+    // Fall back to streaming the resized bytes if storage failed.
     return new Response(new Uint8Array(resizedImage), {
       headers: {
         "Content-Type": "image/png",
-        "CDN-Cache-Control": "s-maxage=86400, stale-while-revalidate=86400",
-        "Cache-Control":
-          "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400",
+        ...CACHE_HEADERS,
       },
     });
   } catch (e) {

--- a/app/(app)/lish/[did]/[publication]/subscribe/SubscribeCard.tsx
+++ b/app/(app)/lish/[did]/[publication]/subscribe/SubscribeCard.tsx
@@ -15,7 +15,9 @@ export const SubscribeCard = (props: {
 }) => {
   let record = props.record;
   let iconUrl = record.icon
-    ? blobRefToSrc(record.icon.ref, new AtUri(props.uri).host)
+    ? blobRefToSrc(record.icon.ref, new AtUri(props.uri).host, undefined, {
+        width: 360,
+      })
     : undefined;
   return (
     <div

--- a/app/(app)/p/[didOrHandle]/[rkey]/opengraph-image.ts
+++ b/app/(app)/p/[didOrHandle]/[rkey]/opengraph-image.ts
@@ -41,11 +41,7 @@ export default async function OpenGraphImage(props: {
     if (document) {
       const docRecord = normalizeDocumentRecord(jsonToLex(document.data));
       if (docRecord?.coverImage) {
-        // Get CID from the blob ref (handle both serialized and hydrated forms)
-        let cid =
-          (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
-          docRecord.coverImage.ref.toString();
-        let res = await coverImageRedirect(did, cid);
+        let res = await coverImageRedirect(did, docRecord.coverImage.ref);
         if (res) return res;
         // Fall through to screenshot if the cover couldn't be cached
       }

--- a/app/(app)/p/[didOrHandle]/[rkey]/opengraph-image.ts
+++ b/app/(app)/p/[didOrHandle]/[rkey]/opengraph-image.ts
@@ -45,7 +45,9 @@ export default async function OpenGraphImage(props: {
         let cid =
           (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
           docRecord.coverImage.ref.toString();
-        return coverImageRedirect(did, cid);
+        let res = await coverImageRedirect(did, cid);
+        if (res) return res;
+        // Fall through to screenshot if the cover couldn't be cached
       }
     }
   }

--- a/app/(app)/p/[didOrHandle]/[rkey]/opengraph-image.ts
+++ b/app/(app)/p/[didOrHandle]/[rkey]/opengraph-image.ts
@@ -2,8 +2,8 @@ import { ogScreenshotResponse } from "src/utils/screenshotPage";
 import { supabaseServerClient } from "supabase/serverClient";
 import { jsonToLex } from "@atproto/lexicon";
 import { idResolver } from "src/identity";
-import { fetchAtprotoBlob } from "app/api/atproto_images/route";
 import { normalizeDocumentRecord } from "src/utils/normalizeRecords";
+import { coverImageRedirect } from "src/utils/ogCoverImageRedirect";
 import { documentUriFilter } from "src/utils/uriHelpers";
 
 // OG content is effectively immutable post-publish, and each regeneration is a
@@ -41,28 +41,11 @@ export default async function OpenGraphImage(props: {
     if (document) {
       const docRecord = normalizeDocumentRecord(jsonToLex(document.data));
       if (docRecord?.coverImage) {
-        try {
-          // Get CID from the blob ref (handle both serialized and hydrated forms)
-          let cid =
-            (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
-            docRecord.coverImage.ref.toString();
-
-          let imageResponse = await fetchAtprotoBlob(did, cid);
-          if (imageResponse) {
-            let imageBlob = await imageResponse.blob();
-
-            // Return the image with appropriate headers
-            return new Response(imageBlob, {
-              headers: {
-                "Content-Type": imageBlob.type || "image/jpeg",
-                "Cache-Control": "public, max-age=3600",
-              },
-            });
-          }
-        } catch (e) {
-          // Fall through to screenshot if cover image fetch fails
-          console.error("Failed to fetch cover image:", e);
-        }
+        // Get CID from the blob ref (handle both serialized and hydrated forms)
+        let cid =
+          (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
+          docRecord.coverImage.ref.toString();
+        return coverImageRedirect(did, cid);
       }
     }
   }

--- a/app/api/atproto_images/route.ts
+++ b/app/api/atproto_images/route.ts
@@ -114,6 +114,63 @@ async function ensureOriginalCached(
   return { url, bytes };
 }
 
+/**
+ * Ensures a resized variant of the blob is cached in storage (resized once
+ * with sharp — Supabase's image transform bills per origin image per month)
+ * and returns its public URL. Falls back to the cached original's URL when a
+ * variant can't be produced, and null when nothing could be cached at all.
+ * Width/height are expected to already be snapped to the image-width ladder.
+ */
+export async function ensureResizedVariantCached(
+  did: string,
+  cid: string,
+  width?: number,
+  height?: number,
+): Promise<string | null> {
+  const variantPath = `${COVER_IMAGE_PREFIX}/resized/w${width ?? 0}-h${height ?? 0}/${cid}`;
+  const variantUrl = publicUrl(variantPath);
+  const existing = await fetch(variantUrl, { method: "HEAD" });
+  if (existing.ok) return variantUrl;
+
+  const original = await ensureOriginalCached(did, cid);
+  if (!original) return null;
+  let bytes = original.bytes;
+  if (!bytes) {
+    const res = await fetch(original.url);
+    if (res.ok) bytes = await res.arrayBuffer();
+  }
+  if (bytes) {
+    try {
+      // rotate() applies EXIF orientation, which imgproxy did
+      // implicitly. withoutEnlargement mirrors imgproxy's no-upscale
+      // default.
+      const resized = await sharp(Buffer.from(bytes), { animated: true })
+        .rotate()
+        .resize({
+          width,
+          height,
+          fit: "inside",
+          withoutEnlargement: true,
+        })
+        .toBuffer({ resolveWithObject: true });
+      const { error } = await supabaseServerClient.storage
+        .from(COVER_IMAGE_BUCKET)
+        .upload(variantPath, new Uint8Array(resized.data), {
+          contentType: `image/${resized.info.format}`,
+          cacheControl: "31536000",
+          upsert: true,
+        });
+      if (!error) return variantUrl;
+      console.log("failed to store cover variant", variantPath, error);
+    } catch (e) {
+      console.log("failed to resize cover image", e);
+    }
+  }
+  // Couldn't produce a variant; the cached original still beats
+  // streaming the full blob.
+  return original.url;
+}
+
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const params = {
@@ -125,51 +182,13 @@ export async function GET(req: NextRequest) {
   const height = parseDimension(url.searchParams.get("height"));
 
   if (width || height) {
-    // Thumbnail: resized once with sharp (Supabase's image transform bills
-    // per origin image per month), stored, and served by redirect.
-    const variantPath = `${COVER_IMAGE_PREFIX}/resized/w${width ?? 0}-h${height ?? 0}/${params.cid}`;
-    const variantUrl = publicUrl(variantPath);
-    const existing = await fetch(variantUrl, { method: "HEAD" });
-    if (existing.ok) return redirect(variantUrl);
-
-    const original = await ensureOriginalCached(params.did, params.cid);
-    if (original) {
-      let bytes = original.bytes;
-      if (!bytes) {
-        const res = await fetch(original.url);
-        if (res.ok) bytes = await res.arrayBuffer();
-      }
-      if (bytes) {
-        try {
-          // rotate() applies EXIF orientation, which imgproxy did
-          // implicitly. withoutEnlargement mirrors imgproxy's no-upscale
-          // default.
-          const resized = await sharp(Buffer.from(bytes), { animated: true })
-            .rotate()
-            .resize({
-              width,
-              height,
-              fit: "inside",
-              withoutEnlargement: true,
-            })
-            .toBuffer({ resolveWithObject: true });
-          const { error } = await supabaseServerClient.storage
-            .from(COVER_IMAGE_BUCKET)
-            .upload(variantPath, new Uint8Array(resized.data), {
-              contentType: `image/${resized.info.format}`,
-              cacheControl: "31536000",
-              upsert: true,
-            });
-          if (!error) return redirect(variantUrl);
-          console.log("failed to store cover variant", variantPath, error);
-        } catch (e) {
-          console.log("failed to resize cover image", e);
-        }
-      }
-      // Couldn't produce a variant; the cached original still beats
-      // streaming the full blob through this function.
-      return redirect(original.url);
-    }
+    const variantUrl = await ensureResizedVariantCached(
+      params.did,
+      params.cid,
+      width,
+      height,
+    );
+    if (variantUrl) return redirect(variantUrl);
     // Fall through to streaming if nothing could be cached.
   } else {
     const original = await ensureOriginalCached(params.did, params.cid);

--- a/app/api/atproto_images/route.ts
+++ b/app/api/atproto_images/route.ts
@@ -1,59 +1,24 @@
 export const runtime = "nodejs";
 
-import { IdResolver } from "@atproto/identity";
 import { NextRequest, NextResponse } from "next/server";
-import sharp from "sharp";
-import { supabaseServerClient } from "supabase/serverClient";
-import { snapToImageWidth } from "supabase/imageSizes";
+import { snapToImageWidth, type ImageWidth } from "supabase/imageSizes";
+import {
+  ensureOriginalCached,
+  ensureResizedVariantCached,
+  fetchAtprotoBlob,
+} from "src/utils/atprotoImages";
 
-let idResolver = new IdResolver();
-
-// Reuse the existing image-cache bucket (see app/api/link_previews/route.ts).
-const COVER_IMAGE_BUCKET = "url-previews";
-const COVER_IMAGE_PREFIX = "post-cover";
 const CACHE_CONTROL =
   "public, max-age=31536000, immutable, s-maxage=86400, stale-while-revalidate=604800";
 // CID-addressed content never changes, so cache it at the edge for a year.
 const CDN_CACHE_CONTROL =
   "public, s-maxage=31536000, immutable, stale-while-revalidate=604800";
 
-/**
- * Fetches a blob from an AT Protocol PDS given a DID and CID
- * Returns the Response object or null if the blob couldn't be fetched
- */
-export async function fetchAtprotoBlob(
-  did: string,
-  cid: string,
-): Promise<Response | null> {
-  if (!did || !cid) return null;
-
-  let identity = await idResolver.did.resolve(did);
-  let service = identity?.service?.find((f) => f.id === "#atproto_pds");
-  if (!service) return null;
-
-  const response = await fetch(
-    `${service.serviceEndpoint}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${cid}`,
-    {
-      headers: {
-        "Accept-Encoding": "gzip, deflate, br, zstd",
-      },
-    },
-  );
-
-  if (!response.ok) return null;
-
-  return response;
-}
-
-function parseDimension(value: string | null): number | undefined {
+function parseDimension(value: string | null): ImageWidth | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
   return snapToImageWidth(parsed);
-}
-
-function publicUrl(path: string) {
-  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/object/public/${COVER_IMAGE_BUCKET}/${path}`;
 }
 
 // Bytes are served straight off Supabase's CDN rather than streamed through
@@ -70,105 +35,6 @@ function redirect(to: string) {
       "CDN-Cache-Control": CDN_CACHE_CONTROL,
     },
   });
-}
-
-/**
- * Ensures the original PDS blob is cached in storage with a well-formed
- * Cache-Control. (Uploads from before the storage-js seconds fix stored a
- * malformed `max-age=public, ...` header, which defeats CDN caching — those
- * get re-uploaded once.) Returns the object's public URL, plus the bytes
- * when they already passed through here so callers can reuse them without
- * another round trip. Null when the blob can't be produced at that URL.
- */
-async function ensureOriginalCached(
-  did: string,
-  cid: string,
-): Promise<{ url: string; bytes: ArrayBuffer | null } | null> {
-  if (!did || !cid) return null;
-  const path = `${COVER_IMAGE_PREFIX}/${cid}`;
-  const url = publicUrl(path);
-
-  const head = await fetch(url, { method: "HEAD" });
-  const malformed = (head.headers.get("cache-control") ?? "").includes(
-    "max-age=public",
-  );
-  if (head.ok && !malformed) return { url, bytes: null };
-
-  let source = head.ok ? await fetch(url) : await fetchAtprotoBlob(did, cid);
-  if (!source || !source.ok) return null;
-  const bytes = await source.arrayBuffer();
-
-  const { error } = await supabaseServerClient.storage
-    .from(COVER_IMAGE_BUCKET)
-    .upload(path, bytes, {
-      contentType: source.headers.get("content-type") || undefined,
-      // storage-js expects seconds, not a header value.
-      cacheControl: "31536000",
-      upsert: true,
-    });
-  if (error) {
-    console.log("failed to cache cover image", error);
-    // With nothing stored at the URL there is nothing to redirect to.
-    if (!head.ok) return null;
-  }
-  return { url, bytes };
-}
-
-/**
- * Ensures a resized variant of the blob is cached in storage (resized once
- * with sharp — Supabase's image transform bills per origin image per month)
- * and returns its public URL. Falls back to the cached original's URL when a
- * variant can't be produced, and null when nothing could be cached at all.
- * Width/height are expected to already be snapped to the image-width ladder.
- */
-export async function ensureResizedVariantCached(
-  did: string,
-  cid: string,
-  width?: number,
-  height?: number,
-): Promise<string | null> {
-  const variantPath = `${COVER_IMAGE_PREFIX}/resized/w${width ?? 0}-h${height ?? 0}/${cid}`;
-  const variantUrl = publicUrl(variantPath);
-  const existing = await fetch(variantUrl, { method: "HEAD" });
-  if (existing.ok) return variantUrl;
-
-  const original = await ensureOriginalCached(did, cid);
-  if (!original) return null;
-  let bytes = original.bytes;
-  if (!bytes) {
-    const res = await fetch(original.url);
-    if (res.ok) bytes = await res.arrayBuffer();
-  }
-  if (bytes) {
-    try {
-      // rotate() applies EXIF orientation, which imgproxy did
-      // implicitly. withoutEnlargement mirrors imgproxy's no-upscale
-      // default.
-      const resized = await sharp(Buffer.from(bytes), { animated: true })
-        .rotate()
-        .resize({
-          width,
-          height,
-          fit: "inside",
-          withoutEnlargement: true,
-        })
-        .toBuffer({ resolveWithObject: true });
-      const { error } = await supabaseServerClient.storage
-        .from(COVER_IMAGE_BUCKET)
-        .upload(variantPath, new Uint8Array(resized.data), {
-          contentType: `image/${resized.info.format}`,
-          cacheControl: "31536000",
-          upsert: true,
-        });
-      if (!error) return variantUrl;
-      console.log("failed to store cover variant", variantPath, error);
-    } catch (e) {
-      console.log("failed to resize cover image", e);
-    }
-  }
-  // Couldn't produce a variant; the cached original still beats
-  // streaming the full blob.
-  return original.url;
 }
 
 export async function GET(req: NextRequest) {

--- a/app/api/auth/email-login/route.ts
+++ b/app/api/auth/email-login/route.ts
@@ -66,7 +66,8 @@ export async function GET(req: NextRequest) {
   let publicationUri =
     subscribePublication ||
     (await publicationUriForHost(new URL(redirect).host));
-  if (publicationUri) confirmUrl.searchParams.set("publication", publicationUri);
+  if (publicationUri)
+    confirmUrl.searchParams.set("publication", publicationUri);
   return NextResponse.redirect(confirmUrl.toString());
 }
 
@@ -77,7 +78,8 @@ async function resolveSubscriptionEmailContext(publicationUri: string) {
     .eq("uri", publicationUri)
     .maybeSingle();
   const normalized = normalizePublicationRecord(publication?.record);
-  const assetsBaseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
+  const assetsBaseUrl =
+    process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
   return {
     publicationName: normalized?.name,
     publicationUrl: normalized?.url,
@@ -86,6 +88,7 @@ async function resolveSubscriptionEmailContext(publicationUri: string) {
           normalized.icon.ref,
           new AtUri(publicationUri).host,
           assetsBaseUrl,
+          { width: 360 },
         )
       : undefined,
   };

--- a/app/api/link_previews/route.ts
+++ b/app/api/link_previews/route.ts
@@ -71,6 +71,10 @@ async function get_link_image_preview(url: string) {
       .toBuffer();
     await supabase.storage.from("url-previews").upload(key, thumbnail, {
       contentType: "image/png",
+      // A day, not a year: the key is a hash of the url and gets upsert-
+      // overwritten when the link is re-previewed, so an immutable cache
+      // would pin stale thumbnails. (storage-js expects seconds.)
+      cacheControl: "86400",
       upsert: true,
     });
   } else {

--- a/app/api/pub_icon/route.ts
+++ b/app/api/pub_icon/route.ts
@@ -1,7 +1,7 @@
 import { AtUri } from "@atproto/syntax";
-import { IdResolver } from "@atproto/identity";
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseServerClient } from "supabase/serverClient";
+import { fetchAtprotoBlob } from "app/api/atproto_images/route";
 import {
   normalizePublicationRecord,
   type NormalizedPublication,
@@ -13,9 +13,32 @@ import {
 import { publicationUriFilter } from "src/utils/uriHelpers";
 import sharp from "sharp";
 
-const idResolver = new IdResolver();
-
 export const runtime = "nodejs";
+
+// Reuse the image-cache bucket (see app/api/atproto_images/route.ts). Variants
+// are keyed by CID, so they're immutable; the redirect response itself stays
+// short-lived since the publication record's icon can change.
+const ICON_BUCKET = "url-previews";
+const ICON_PREFIX = "pub-icon/w96";
+const CACHE_HEADERS = {
+  "Cache-Control":
+    "public, max-age=3600, s-maxage=3600, stale-while-revalidate=2592000",
+  "CDN-Cache-Control": "s-maxage=3600, stale-while-revalidate=2592000",
+};
+
+function variantUrl(cid: string) {
+  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/object/public/${ICON_BUCKET}/${ICON_PREFIX}/${cid}`;
+}
+
+// Bytes are served off Supabase's CDN rather than streamed through this
+// function: bytes leaving Vercel bill at fast data transfer rates while
+// Supabase serves the same bytes as cheap cached egress.
+function redirect(to: string) {
+  return new NextResponse(null, {
+    status: 302,
+    headers: { Location: to, ...CACHE_HEADERS },
+  });
+}
 
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams;
@@ -92,9 +115,7 @@ export async function GET(req: NextRequest) {
       return new NextResponse(svg, {
         headers: {
           "Content-Type": "image/svg+xml",
-          "Cache-Control":
-            "public, max-age=3600, s-maxage=3600, stale-while-revalidate=2592000",
-          "CDN-Cache-Control": "s-maxage=3600, stale-while-revalidate=2592000",
+          ...CACHE_HEADERS,
         },
       });
     }
@@ -107,21 +128,12 @@ export async function GET(req: NextRequest) {
       "$link"
     ];
 
-    // Fetch the blob from the PDS
-    const identity = await idResolver.did.resolve(pubUri.host);
-    const service = identity?.service?.find((f) => f.id === "#atproto_pds");
-    if (!service) return new NextResponse(null, { status: 404 });
+    // Already resized and stored for this CID?
+    const existing = await fetch(variantUrl(cid), { method: "HEAD" });
+    if (existing.ok) return redirect(variantUrl(cid));
 
-    const blobResponse = await fetch(
-      `${service.serviceEndpoint}/xrpc/com.atproto.sync.getBlob?did=${pubUri.host}&cid=${cid}`,
-      {
-        headers: {
-          "Accept-Encoding": "gzip, deflate, br, zstd",
-        },
-      },
-    );
-
-    if (!blobResponse.ok) {
+    const blobResponse = await fetchAtprotoBlob(pubUri.host, cid);
+    if (!blobResponse) {
       return new NextResponse(null, { status: 404 });
     }
 
@@ -137,14 +149,22 @@ export async function GET(req: NextRequest) {
       .webp({ quality: 90 })
       .toBuffer();
 
-    // Return with caching headers
+    const { error } = await supabaseServerClient.storage
+      .from(ICON_BUCKET)
+      .upload(`${ICON_PREFIX}/${cid}`, new Uint8Array(resizedImage), {
+        contentType: "image/webp",
+        // storage-js expects seconds, not a header value.
+        cacheControl: "31536000",
+        upsert: true,
+      });
+    if (!error) return redirect(variantUrl(cid));
+    console.log("failed to store pub icon variant", cid, error);
+
+    // Fall back to streaming the resized bytes if storage failed.
     return new NextResponse(resizedImage, {
       headers: {
         "Content-Type": "image/webp",
-        // Cache for 1 hour, but serve stale for much longer while revalidating
-        "Cache-Control":
-          "public, max-age=3600, s-maxage=3600, stale-while-revalidate=2592000",
-        "CDN-Cache-Control": "s-maxage=3600, stale-while-revalidate=2592000",
+        ...CACHE_HEADERS,
       },
     });
   } catch (error) {

--- a/app/api/pub_icon/route.ts
+++ b/app/api/pub_icon/route.ts
@@ -1,7 +1,10 @@
 import { AtUri } from "@atproto/syntax";
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseServerClient } from "supabase/serverClient";
-import { fetchAtprotoBlob } from "app/api/atproto_images/route";
+import {
+  ensureDerivedImageCached,
+  fetchAtprotoBlob,
+} from "src/utils/atprotoImages";
 import {
   normalizePublicationRecord,
   type NormalizedPublication,
@@ -15,30 +18,14 @@ import sharp from "sharp";
 
 export const runtime = "nodejs";
 
-// Reuse the image-cache bucket (see app/api/atproto_images/route.ts). Variants
-// are keyed by CID, so they're immutable; the redirect response itself stays
-// short-lived since the publication record's icon can change.
-const ICON_BUCKET = "url-previews";
+// Variants are keyed by CID, so they're immutable; the redirect response
+// itself stays short-lived since the publication record's icon can change.
 const ICON_PREFIX = "pub-icon/w96";
 const CACHE_HEADERS = {
   "Cache-Control":
     "public, max-age=3600, s-maxage=3600, stale-while-revalidate=2592000",
   "CDN-Cache-Control": "s-maxage=3600, stale-while-revalidate=2592000",
 };
-
-function variantUrl(cid: string) {
-  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/object/public/${ICON_BUCKET}/${ICON_PREFIX}/${cid}`;
-}
-
-// Bytes are served off Supabase's CDN rather than streamed through this
-// function: bytes leaving Vercel bill at fast data transfer rates while
-// Supabase serves the same bytes as cheap cached egress.
-function redirect(to: string) {
-  return new NextResponse(null, {
-    status: 302,
-    headers: { Location: to, ...CACHE_HEADERS },
-  });
-}
 
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams;
@@ -128,40 +115,34 @@ export async function GET(req: NextRequest) {
       "$link"
     ];
 
-    // Already resized and stored for this CID?
-    const existing = await fetch(variantUrl(cid), { method: "HEAD" });
-    if (existing.ok) return redirect(variantUrl(cid));
-
-    const blobResponse = await fetchAtprotoBlob(pubUri.host, cid);
-    if (!blobResponse) {
-      return new NextResponse(null, { status: 404 });
-    }
-
-    // Get the image buffer
-    const imageBuffer = await blobResponse.arrayBuffer();
-
-    // Resize to 96x96 using Sharp
-    const resizedImage = await sharp(Buffer.from(imageBuffer))
-      .resize(96, 96, {
-        fit: "cover",
-        position: "center",
-      })
-      .webp({ quality: 90 })
-      .toBuffer();
-
-    const { error } = await supabaseServerClient.storage
-      .from(ICON_BUCKET)
-      .upload(`${ICON_PREFIX}/${cid}`, new Uint8Array(resizedImage), {
-        contentType: "image/webp",
-        // storage-js expects seconds, not a header value.
-        cacheControl: "31536000",
-        upsert: true,
+    let resized: Uint8Array | null = null;
+    const url = await ensureDerivedImageCached(
+      `${ICON_PREFIX}/${cid}`,
+      async () => {
+        const blobResponse = await fetchAtprotoBlob(pubUri.host, cid);
+        if (!blobResponse) return null;
+        // Resize to 96x96 using Sharp
+        resized = new Uint8Array(
+          await sharp(Buffer.from(await blobResponse.arrayBuffer()))
+            .resize(96, 96, {
+              fit: "cover",
+              position: "center",
+            })
+            .webp({ quality: 90 })
+            .toBuffer(),
+        );
+        return { bytes: resized, contentType: "image/webp" };
+      },
+    );
+    if (url)
+      return new NextResponse(null, {
+        status: 302,
+        headers: { Location: url, ...CACHE_HEADERS },
       });
-    if (!error) return redirect(variantUrl(cid));
-    console.log("failed to store pub icon variant", cid, error);
+    if (!resized) return new NextResponse(null, { status: 404 });
 
     // Fall back to streaming the resized bytes if storage failed.
-    return new NextResponse(resizedImage, {
+    return new NextResponse(resized, {
       headers: {
         "Content-Type": "image/webp",
         ...CACHE_HEADERS,

--- a/app/api/quote_screenshot/route.ts
+++ b/app/api/quote_screenshot/route.ts
@@ -20,7 +20,14 @@ export async function GET(req: NextRequest) {
 
   let image = await screenshotBskyCardImage(parsed.toString());
   if (!image) return new Response("Screenshot failed", { status: 502 });
+  // Cache at the edge so the warm-up fetch above actually saves the second
+  // render when the user posts.
   return new Response(new Uint8Array(image), {
-    headers: { "Content-Type": "image/webp" },
+    headers: {
+      "Content-Type": "image/webp",
+      "Cache-Control":
+        "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      "CDN-Cache-Control": "s-maxage=86400, stale-while-revalidate=604800",
+    },
   });
 }

--- a/app/login/confirm/page.tsx
+++ b/app/login/confirm/page.tsx
@@ -30,7 +30,12 @@ export default async function LoginConfirmPage(props: {
     let record = normalizePublicationRecord(publication?.record);
     if (publication && record) {
       let iconUrl = record.icon
-        ? blobRefToSrc(record.icon.ref, new AtUri(publication.uri).host)
+        ? blobRefToSrc(
+            record.icon.ref,
+            new AtUri(publication.uri).host,
+            undefined,
+            { width: 360 },
+          )
         : undefined;
       return (
         <PublicationThemeProvider

--- a/components/ActionBar/Publications.tsx
+++ b/components/ActionBar/Publications.tsx
@@ -114,7 +114,12 @@ const PublicationOption = (props: {
           <PubIcon
             icon={
               record.icon
-                ? blobRefToSrc(record.icon.ref, new AtUri(props.uri).host)
+                ? blobRefToSrc(
+                    record.icon.ref,
+                    new AtUri(props.uri).host,
+                    undefined,
+                    { width: 360 },
+                  )
                 : undefined
             }
             pubName={record.name}

--- a/components/Blocks/StandardSitePostBlock/StandardSitePostItem.tsx
+++ b/components/Blocks/StandardSitePostBlock/StandardSitePostItem.tsx
@@ -284,6 +284,8 @@ function PubInfo({
             ? blobRefToSrc(
                 publication.record.icon.ref,
                 new AtUri(publication.uri).host,
+                undefined,
+                { width: 360 },
               )
             : undefined
         }

--- a/components/Blocks/StandardSitePublicationBlock/StandardSitePublicationItem.tsx
+++ b/components/Blocks/StandardSitePublicationBlock/StandardSitePublicationItem.tsx
@@ -48,7 +48,9 @@ export function StandardSitePublicationItemView({
     host = undefined;
   }
   const iconSrc =
-    record.icon && host ? blobRefToSrc(record.icon.ref, host) : undefined;
+    record.icon && host
+      ? blobRefToSrc(record.icon.ref, host, undefined, { width: 360 })
+      : undefined;
 
   const authorLabel = author
     ? formatBylineNames(

--- a/components/PostListing.tsx
+++ b/components/PostListing.tsx
@@ -58,7 +58,12 @@ export const PostListing = (props: Post & { selected?: boolean }) => {
 
   let backgroundImage =
     themeRecord?.backgroundImage?.image?.ref && uri
-      ? blobRefToSrc(themeRecord.backgroundImage.image.ref, new AtUri(uri).host)
+      ? blobRefToSrc(
+          themeRecord.backgroundImage.image.ref,
+          new AtUri(uri).host,
+          undefined,
+          { width: 2000 },
+        )
       : null;
 
   let backgroundImageRepeat = themeRecord?.backgroundImage?.repeat;
@@ -209,6 +214,8 @@ const PubInfo = (props: {
               ? blobRefToSrc(
                   props.pubRecord.icon.ref,
                   new AtUri(props.uri).host,
+                  undefined,
+                  { width: 360 },
                 )
               : undefined
           }

--- a/components/ThemeManager/PublicationThemeProvider.tsx
+++ b/components/ThemeManager/PublicationThemeProvider.tsx
@@ -90,6 +90,8 @@ export function PublicationBackgroundProvider(props: {
         ? blobRefToSrc(
             props.record?.theme?.backgroundImage?.image?.ref,
             props.pub_creator,
+            undefined,
+            { width: 2000 },
           )
         : null;
 

--- a/emails/post.tsx
+++ b/emails/post.tsx
@@ -1135,7 +1135,9 @@ const BlockRenderer = ({
     );
   }
   if (PubLeafletBlocksImage.isMain(block)) {
-    const src = blobRefToSrc(block.image.ref, did, assetsBaseUrl);
+    const src = blobRefToSrc(block.image.ref, did, assetsBaseUrl, {
+      width: 800,
+    });
     // Deliberately no numeric `width`/`height` HTML attributes: Outlook
     // honors those over CSS `max-width`, so a 1200px natural-size photo
     // would blow out our 28rem container. `max-width: <natural>px` keeps
@@ -1152,7 +1154,9 @@ const BlockRenderer = ({
   }
   if (PubLeafletBlocksWebsite.isMain(block)) {
     const previewSrc = block.previewImage
-      ? blobRefToSrc(block.previewImage.ref, did, assetsBaseUrl)
+      ? blobRefToSrc(block.previewImage.ref, did, assetsBaseUrl, {
+          width: 360,
+        })
       : undefined;
     return (
       <LinkBlock
@@ -1232,7 +1236,11 @@ const BlockRenderer = ({
     const post = standardSitePosts?.[block.uri];
     if (!post) {
       return (
-        <BlockDataNotFound label="Post not found." theme={theme} colors={colors} />
+        <BlockDataNotFound
+          label="Post not found."
+          theme={theme}
+          colors={colors}
+        />
       );
     }
     // default to "medium" to match the draft (StandardSitePostBlock),
@@ -1275,9 +1283,7 @@ const BlockRenderer = ({
       />
     );
   }
-  return (
-    <BlockNotSupported theme={theme} colors={colors} postUrl={postUrl} />
-  );
+  return <BlockNotSupported theme={theme} colors={colors} postUrl={postUrl} />;
 };
 
 // Matches the published web renderer's notice when a referenced standard-site

--- a/emails/standardSiteBlocks.tsx
+++ b/emails/standardSiteBlocks.tsx
@@ -244,7 +244,10 @@ export const StandardSitePostEmailBlock = ({
   // publication theme, else the post's own theme; standalone (no publication)
   // flips usePubTheme to standalone defaults.
   const cardTheme = showPublicationTheme
-    ? resolveCardTheme([post.publication?.record, post.record], !post.publication)
+    ? resolveCardTheme(
+        [post.publication?.record, post.record],
+        !post.publication,
+      )
     : outerCardTheme(theme);
   const colors = resolveColors(cardTheme);
   const cardBg = cardTheme.pageBackground;
@@ -257,9 +260,7 @@ export const StandardSitePostEmailBlock = ({
   const authorLabel =
     post.contributors.length > 0
       ? formatBylineNames(
-          post.contributors
-            .map(bylineLabel)
-            .filter((l): l is string => !!l),
+          post.contributors.map(bylineLabel).filter((l): l is string => !!l),
         ) || undefined
       : bylineLabel(post.author ?? { displayName: null, handle: null });
   // Same Intl options as the web's LocalizedDate; UTC matches its SSR default
@@ -272,8 +273,7 @@ export const StandardSitePostEmailBlock = ({
         timeZone: "UTC",
       })
     : undefined;
-  const description =
-    post.record.description || getFirstParagraph(post.record);
+  const description = post.record.description || getFirstParagraph(post.record);
 
   let postDid: string | undefined;
   try {
@@ -293,14 +293,15 @@ export const StandardSitePostEmailBlock = ({
 
   let pubDid: string | undefined;
   try {
-    pubDid = post.publication ? new AtUri(post.publication.uri).host : undefined;
+    pubDid = post.publication
+      ? new AtUri(post.publication.uri).host
+      : undefined;
   } catch {
     pubDid = undefined;
   }
   const showPubInfo =
     !!post.publication?.record &&
-    (!currentPublicationUri ||
-      post.publication.uri !== currentPublicationUri);
+    (!currentPublicationUri || post.publication.uri !== currentPublicationUri);
   const pubInfo =
     showPubInfo && post.publication?.record ? (
       <PubInfoLine
@@ -312,6 +313,7 @@ export const StandardSitePostEmailBlock = ({
                 post.publication.record.icon.ref,
                 pubDid,
                 assetsBaseUrl,
+                { width: 360 },
               )
             : undefined
         }
@@ -363,9 +365,7 @@ export const StandardSitePostEmailBlock = ({
       <Link href={docUrl} style={cellLinkStyle}>
         {title}
         {size !== "small" && description ? (
-          <span
-            style={descriptionStyle(colors, cardTheme.bodyFont, 16)}
-          >
+          <span style={descriptionStyle(colors, cardTheme.bodyFont, 16)}>
             {description}
           </span>
         ) : null}
@@ -483,7 +483,7 @@ export const StandardSitePublicationEmailBlock = ({
 
   const iconSrc =
     record.icon && host
-      ? blobRefToSrc(record.icon.ref, host, assetsBaseUrl)
+      ? blobRefToSrc(record.icon.ref, host, assetsBaseUrl, { width: 360 })
       : undefined;
 
   const authorLabel = author ? bylineLabel(author) : undefined;

--- a/src/utils/atprotoImages.ts
+++ b/src/utils/atprotoImages.ts
@@ -1,0 +1,176 @@
+import { IdResolver } from "@atproto/identity";
+import sharp from "sharp";
+import { supabaseServerClient } from "supabase/serverClient";
+import type { ImageWidth } from "supabase/imageSizes";
+
+// Cached-image machinery shared by /api/atproto_images, the publication icon
+// routes, and the post OG images. Images derived from PDS blobs are stored in
+// the url-previews bucket and served off Supabase's CDN by redirect rather
+// than streamed through Vercel: bytes leaving Vercel bill at fast data
+// transfer rates (currently in overage), while Supabase serves the same bytes
+// as cheap cached egress.
+
+let idResolver = new IdResolver();
+
+// Reuse the existing image-cache bucket (see app/api/link_previews/route.ts).
+const IMAGE_CACHE_BUCKET = "url-previews";
+const COVER_IMAGE_PREFIX = "post-cover";
+// storage-js expects seconds, not a header value.
+const STORAGE_CACHE_SECONDS = "31536000";
+
+export function imageCacheUrl(path: string) {
+  return `${process.env.NEXT_PUBLIC_SUPABASE_API_URL}/storage/v1/object/public/${IMAGE_CACHE_BUCKET}/${path}`;
+}
+
+/**
+ * Fetches a blob from an AT Protocol PDS given a DID and CID
+ * Returns the Response object or null if the blob couldn't be fetched
+ */
+export async function fetchAtprotoBlob(
+  did: string,
+  cid: string,
+): Promise<Response | null> {
+  if (!did || !cid) return null;
+
+  let identity = await idResolver.did.resolve(did);
+  let service = identity?.service?.find((f) => f.id === "#atproto_pds");
+  if (!service) return null;
+
+  const response = await fetch(
+    `${service.serviceEndpoint}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${cid}`,
+    {
+      headers: {
+        "Accept-Encoding": "gzip, deflate, br, zstd",
+      },
+    },
+  );
+
+  if (!response.ok) return null;
+
+  return response;
+}
+
+/**
+ * Ensures the original PDS blob is cached in storage with a well-formed
+ * Cache-Control. (Uploads from before the storage-js seconds fix stored a
+ * malformed `max-age=public, ...` header, which defeats CDN caching — those
+ * get re-uploaded once.) Returns the object's public URL, plus the bytes
+ * when they already passed through here so callers can reuse them without
+ * another round trip. Null when the blob can't be produced at that URL.
+ */
+export async function ensureOriginalCached(
+  did: string,
+  cid: string,
+): Promise<{ url: string; bytes: ArrayBuffer | null } | null> {
+  if (!did || !cid) return null;
+  const path = `${COVER_IMAGE_PREFIX}/${cid}`;
+  const url = imageCacheUrl(path);
+
+  const head = await fetch(url, { method: "HEAD" });
+  const malformed = (head.headers.get("cache-control") ?? "").includes(
+    "max-age=public",
+  );
+  if (head.ok && !malformed) return { url, bytes: null };
+
+  let source = head.ok ? await fetch(url) : await fetchAtprotoBlob(did, cid);
+  if (!source || !source.ok) return null;
+  const bytes = await source.arrayBuffer();
+
+  const { error } = await supabaseServerClient.storage
+    .from(IMAGE_CACHE_BUCKET)
+    .upload(path, bytes, {
+      contentType: source.headers.get("content-type") || undefined,
+      cacheControl: STORAGE_CACHE_SECONDS,
+      upsert: true,
+    });
+  if (error) {
+    console.log("failed to cache cover image", error);
+    // With nothing stored at the URL there is nothing to redirect to.
+    if (!head.ok) return null;
+  }
+  return { url, bytes };
+}
+
+/**
+ * Ensures a derived image exists at `path` in the cache bucket, calling
+ * `produce` for the bytes on a miss. Returns its public URL, or null when the
+ * image couldn't be produced or stored.
+ */
+export async function ensureDerivedImageCached(
+  path: string,
+  produce: () => Promise<{ bytes: Uint8Array; contentType: string } | null>,
+): Promise<string | null> {
+  const url = imageCacheUrl(path);
+  const head = await fetch(url, { method: "HEAD" });
+  if (head.ok) return url;
+
+  const produced = await produce();
+  if (!produced) return null;
+
+  const { error } = await supabaseServerClient.storage
+    .from(IMAGE_CACHE_BUCKET)
+    .upload(path, produced.bytes, {
+      contentType: produced.contentType,
+      cacheControl: STORAGE_CACHE_SECONDS,
+      upsert: true,
+    });
+  if (error) {
+    console.log("failed to store derived image", path, error);
+    return null;
+  }
+  return url;
+}
+
+/**
+ * Ensures a resized variant of the blob is cached in storage (resized once
+ * with sharp — Supabase's image transform bills per origin image per month)
+ * and returns its public URL. Falls back to the cached original's URL when a
+ * variant can't be produced, and null when nothing could be cached at all.
+ */
+export async function ensureResizedVariantCached(
+  did: string,
+  cid: string,
+  width?: ImageWidth,
+  height?: ImageWidth,
+): Promise<string | null> {
+  const variantUrl = await ensureDerivedImageCached(
+    `${COVER_IMAGE_PREFIX}/resized/w${width ?? 0}-h${height ?? 0}/${cid}`,
+    async () => {
+      const original = await ensureOriginalCached(did, cid);
+      if (!original) return null;
+      let bytes = original.bytes;
+      if (!bytes) {
+        const res = await fetch(original.url);
+        if (res.ok) bytes = await res.arrayBuffer();
+      }
+      if (!bytes) return null;
+      try {
+        // rotate() applies EXIF orientation, which imgproxy did
+        // implicitly. withoutEnlargement mirrors imgproxy's no-upscale
+        // default.
+        const resized = await sharp(Buffer.from(bytes), { animated: true })
+          .rotate()
+          .resize({
+            width,
+            height,
+            fit: "inside",
+            withoutEnlargement: true,
+          })
+          .toBuffer({ resolveWithObject: true });
+        return {
+          bytes: new Uint8Array(resized.data),
+          contentType: `image/${resized.info.format}`,
+        };
+      } catch (e) {
+        console.log("failed to resize cover image", e);
+        return null;
+      }
+    },
+  );
+  if (variantUrl) return variantUrl;
+  // Couldn't produce a variant; the cached original (if any) still beats
+  // streaming the full blob. Re-checking it costs a HEAD on this rare path
+  // only.
+  const original = await ensureOriginalCached(did, cid);
+  return original?.url ?? null;
+}

--- a/src/utils/blobRefToSrc.ts
+++ b/src/utils/blobRefToSrc.ts
@@ -1,4 +1,5 @@
 import { BlobRef } from "@atproto/lexicon";
+import type { ImageWidth } from "supabase/imageSizes";
 
 // `baseUrl` produces an absolute URL (needed for outbound email where the proxy
 // path can't resolve against the document origin).
@@ -13,7 +14,7 @@ export const blobRefToSrc = (
   b: BlobRef["ref"],
   did: string,
   baseUrl?: string,
-  transform?: { width?: number; height?: number },
+  transform?: { width?: ImageWidth; height?: ImageWidth },
 ) => {
   const link = (b as unknown as { $link: string })["$link"];
   if (link.startsWith("http://") || link.startsWith("https://")) return link;
@@ -27,4 +28,4 @@ export const blobRefToSrc = (
 
 // Display widths (px) for cover-image thumbnails, used to request a right-sized
 // transform instead of shipping the full-resolution blob.
-export const COVER_THUMBNAIL_WIDTH = { large: 800, medium: 360 };
+export const COVER_THUMBNAIL_WIDTH = { large: 800, medium: 360 } as const;

--- a/src/utils/bskyPostEmbed.ts
+++ b/src/utils/bskyPostEmbed.ts
@@ -41,7 +41,9 @@ export function bskyPostEmbed(args: {
           title: pub.name,
           icon:
             pub.icon && args.pubOwnerDid
-              ? blobRefToSrc(pub.icon.ref, args.pubOwnerDid)
+              ? blobRefToSrc(pub.icon.ref, args.pubOwnerDid, undefined, {
+                  width: 360,
+                })
               : undefined,
         },
         associatedRefs: [

--- a/src/utils/ogCoverImageRedirect.ts
+++ b/src/utils/ogCoverImageRedirect.ts
@@ -1,13 +1,26 @@
-// 302 to the cached /api/atproto_images proxy for a post's cover image, used
-// by the post opengraph-image routes. width=1200 requests a variant sized for
-// unfurl cards instead of the full-resolution blob. Absolute URL because some
-// unfurl bots mishandle a relative Location.
-export function coverImageRedirect(did: string, cid: string) {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
+import { ensureResizedVariantCached } from "app/api/atproto_images/route";
+import { snapToImageWidth } from "supabase/imageSizes";
+
+// 302 straight to the storage-cached cover variant for a post's
+// opengraph-image route. A single hop rather than bouncing through
+// /api/atproto_images: og-image fetchers are the flakiest HTTP clients around,
+// and a two-hop cross-origin chain is where they give up. width=1200 requests
+// a variant sized for unfurl cards instead of the full-resolution blob.
+// Returns null when no variant could be cached so callers can fall back to
+// the screenshot.
+export async function coverImageRedirect(did: string, cid: string) {
+  const url = await ensureResizedVariantCached(
+    did,
+    cid,
+    snapToImageWidth(1200),
+  );
+  if (!url) return null;
   return new Response(null, {
     status: 302,
     headers: {
-      Location: `${baseUrl.replace(/\/$/, "")}/api/atproto_images?did=${did}&cid=${cid}&width=1200&v=1`,
+      // A day, not a year: a republish can swap the cover image at the same
+      // route URL.
+      Location: url,
       "Cache-Control":
         "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
       "CDN-Cache-Control":

--- a/src/utils/ogCoverImageRedirect.ts
+++ b/src/utils/ogCoverImageRedirect.ts
@@ -1,19 +1,17 @@
-import { ensureResizedVariantCached } from "app/api/atproto_images/route";
-import { snapToImageWidth } from "supabase/imageSizes";
+import { BlobRef } from "@atproto/lexicon";
+import { ensureResizedVariantCached } from "src/utils/atprotoImages";
 
 // 302 straight to the storage-cached cover variant for a post's
 // opengraph-image route. A single hop rather than bouncing through
-// /api/atproto_images: og-image fetchers are the flakiest HTTP clients around,
-// and a two-hop cross-origin chain is where they give up. width=1200 requests
-// a variant sized for unfurl cards instead of the full-resolution blob.
-// Returns null when no variant could be cached so callers can fall back to
-// the screenshot.
-export async function coverImageRedirect(did: string, cid: string) {
-  const url = await ensureResizedVariantCached(
-    did,
-    cid,
-    snapToImageWidth(1200),
-  );
+// /api/atproto_images: og-image fetchers are the flakiest HTTP clients
+// around, and a two-hop cross-origin chain is where they give up. 1200 (a
+// ladder width) requests a variant sized for unfurl cards instead of the
+// full-resolution blob. Returns null when no variant could be cached so
+// callers can fall back to the screenshot.
+export async function coverImageRedirect(did: string, ref: BlobRef["ref"]) {
+  // Handle both serialized and hydrated forms of the blob ref
+  const cid = (ref as unknown as { $link: string })["$link"] || ref.toString();
+  const url = await ensureResizedVariantCached(did, cid, 1200);
   if (!url) return null;
   return new Response(null, {
     status: 302,

--- a/src/utils/ogCoverImageRedirect.ts
+++ b/src/utils/ogCoverImageRedirect.ts
@@ -1,0 +1,17 @@
+// 302 to the cached /api/atproto_images proxy for a post's cover image, used
+// by the post opengraph-image routes. width=1200 requests a variant sized for
+// unfurl cards instead of the full-resolution blob. Absolute URL because some
+// unfurl bots mishandle a relative Location.
+export function coverImageRedirect(did: string, cid: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://leaflet.pub";
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${baseUrl.replace(/\/$/, "")}/api/atproto_images?did=${did}&cid=${cid}&width=1200&v=1`,
+      "Cache-Control":
+        "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      "CDN-Cache-Control":
+        "public, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  });
+}

--- a/src/utils/screenshotPage.ts
+++ b/src/utils/screenshotPage.ts
@@ -102,6 +102,7 @@ export async function ogScreenshotResponse(
       // each miss is a multi-second remote-browser render.
       "Cache-Control":
         "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      "CDN-Cache-Control": "s-maxage=86400, stale-while-revalidate=604800",
     },
   });
 }

--- a/src/utils/uploadCoverImageThumb.ts
+++ b/src/utils/uploadCoverImageThumb.ts
@@ -1,6 +1,6 @@
 import sharp from "sharp";
 import { BlobRef } from "@atproto/api";
-import { fetchAtprotoBlob } from "app/api/atproto_images/route";
+import { fetchAtprotoBlob } from "src/utils/atprotoImages";
 
 // Fetch a document's cover image from its author's PDS, resize it to a Bluesky
 // external-card thumbnail (1200x630 webp), and upload it via `uploadThumb`.

--- a/src/utils/wordmark.ts
+++ b/src/utils/wordmark.ts
@@ -1,4 +1,5 @@
 import type { PubLeafletPublication } from "lexicons/api";
+import { snapToImageWidth } from "supabase/imageSizes";
 import { blobRefToSrc } from "./blobRefToSrc";
 
 export type WordmarkData = { src: string; width?: number };
@@ -17,7 +18,7 @@ export function wordmarkFromTheme(
     // Request a variant sized for the configured display width (2x for hidpi)
     // instead of the full-resolution blob.
     src: blobRefToSrc(wordmark.image.ref, did, undefined, {
-      width: (wordmark.width ?? 400) * 2,
+      width: snapToImageWidth((wordmark.width ?? 400) * 2),
     }),
     width: wordmark.width ?? undefined,
   };

--- a/src/utils/wordmark.ts
+++ b/src/utils/wordmark.ts
@@ -14,7 +14,11 @@ export function wordmarkFromTheme(
   const wordmark = theme?.wordmark;
   if (!wordmark?.image?.ref) return null;
   return {
-    src: blobRefToSrc(wordmark.image.ref, did),
+    // Request a variant sized for the configured display width (2x for hidpi)
+    // instead of the full-resolution blob.
+    src: blobRefToSrc(wordmark.image.ref, did, undefined, {
+      width: (wordmark.width ?? 400) * 2,
+    }),
     width: wordmark.width ?? undefined,
   };
 }

--- a/supabase/imageSizes.d.ts
+++ b/supabase/imageSizes.d.ts
@@ -1,0 +1,8 @@
+// Type companion for imageSizes.js (which stays CommonJS so next.config.js
+// can require it) — keep the union in sync with IMAGE_WIDTHS there. Typing
+// widths as this union lets call sites request tiers with plain literals
+// while the compiler rejects off-ladder values.
+export type ImageWidth = 360 | 800 | 1200 | 2000;
+// Mutable array type because next.config.js assigns it to `deviceSizes`.
+export const IMAGE_WIDTHS: ImageWidth[];
+export function snapToImageWidth(width: number): ImageWidth;


### PR DESCRIPTION
## Summary

Refactors image caching logic for AT Protocol blobs into a reusable utility module (`src/utils/atprotoImages.ts`), eliminating duplication across multiple routes and enabling consistent image resizing/caching behavior.

## Changes

### New Files
- **`src/utils/atprotoImages.ts`**: Centralized image caching machinery with three main exports:
  - `fetchAtprotoBlob()`: Fetches blobs from PDS given DID and CID
  - `ensureOriginalCached()`: Caches original PDS blobs to Supabase with proper Cache-Control headers
  - `ensureDerivedImageCached()`: Generic caching for derived images (resized variants, etc.)
  - `ensureResizedVariantCached()`: Resizes images with sharp and caches variants, with fallback to original
  - `imageCacheUrl()`: Constructs public URLs for cached images

- **`src/utils/ogCoverImageRedirect.ts`**: New helper for OG image routes to redirect to cached cover variants instead of streaming

- **`supabase/imageSizes.d.ts`**: TypeScript type definitions for image width tiers (360, 800, 1200, 2000)

### Modified Files

**API Routes:**
- `app/api/atproto_images/route.ts`: Simplified to use new utility functions, reducing ~60 lines of duplicated caching logic
- `app/api/pub_icon/route.ts`: Refactored to use `ensureDerivedImageCached()` for icon resizing, now redirects to cached variants instead of streaming
- `app/(app)/lish/[did]/[publication]/icon/route.ts`: Same refactoring for favicon generation

**OG Image Routes:**
- `app/(app)/lish/[did]/[publication]/[rkey]/opengraph-image.ts`: Uses new `coverImageRedirect()` helper for single-hop redirect to cached cover images
- `app/(app)/p/[didOrHandle]/[rkey]/opengraph-image.ts`: Same refactoring

**Image Rendering:**
- `src/utils/blobRefToSrc.ts`: Added optional `transform` parameter to support image width tiers
- `app/(app)/lish/[did]/[publication]/[rkey]/PublishedImageGallery.tsx`: Grid/strip cells now request 1200px tier; lightbox gets full-resolution
- `emails/post.tsx`: Email images now request appropriately-sized variants (800px for images, 360px for website previews)
- `emails/standardSiteBlocks.tsx`: Minor formatting cleanup
- Multiple component files: Updated `blobRefToSrc()` calls to pass width transforms where appropriate

**Other:**
- `src/utils/uploadCoverImageThumb.ts`: Import updated to use new utility location
- `app/api/link_previews/route.ts`: Added cache control header for thumbnail storage
- `app/api/quote_screenshot/route.ts`: Added edge caching headers
- `src/utils/screenshotPage.ts`: Added CDN cache control header

## Benefits

1. **Eliminates duplication**: Image caching logic was previously scattered across three separate routes
2. **Consistent behavior**: All image caching now uses the same machinery with proper Cache-Control headers
3. **Bandwidth optimization**: Resized variants are cached once and served via CDN redirect instead of streaming through Vercel
4. **Responsive images**: Components can now request appropriately-sized variants (e.g., 1200px for web, 800px for email) instead of always fetching full-resolution
5. **Fallback strategy**: Routes gracefully fall back to streaming if caching fails, rather than failing entirely

## Testing

- Existing routes continue to work with simplified implementations
- Image caching behavior is now centralized and testable
- No new dependencies added

https://claude.ai/code/session_01TG1Z2RXovEdV9MZVqc5yDM