### PR TITLE
Optimize feed generation and publication queries

### DIFF
--- a/app/(app)/lish/[did]/[publication]/DefaultPublicationHomepage.tsx
+++ b/app/(app)/lish/[did]/[publication]/DefaultPublicationHomepage.tsx
@@ -42,7 +42,9 @@ export const DefaultPublicationHomepage = ({
       record_uri: string | null;
       sort_order: string;
     }[];
-    documents_in_publications: {
+    // Only the client theme preview supplies this; server callers resolve
+    // `posts` themselves.
+    documents_in_publications?: {
       documents: {
         uri: string;
         data: unknown;

--- a/app/(app)/lish/[did]/[publication]/DefaultPublicationHomepage.tsx
+++ b/app/(app)/lish/[did]/[publication]/DefaultPublicationHomepage.tsx
@@ -12,10 +12,7 @@ import {
   PublicationPostsList,
   type PublicationPostsListFakePost,
 } from "./PublicationPostsList";
-import {
-  buildPublicationPosts,
-  type PublicationPostsListPost,
-} from "./buildPublicationPosts";
+import { type PublicationPostsListPost } from "./buildPublicationPosts";
 
 type FakePost = PublicationPostsListFakePost;
 
@@ -42,33 +39,19 @@ export const DefaultPublicationHomepage = ({
       record_uri: string | null;
       sort_order: string;
     }[];
-    // Only the client theme preview supplies this; server callers resolve
-    // `posts` themselves.
-    documents_in_publications?: {
-      documents: {
-        uri: string;
-        data: unknown;
-        comments_on_documents: { count: number }[];
-        document_mentions_in_bsky: { count: number }[];
-        recommends_on_documents: { count: number }[];
-      } | null;
-    }[];
   };
   did: string;
   profile: { did: string; displayName?: string; handle: string } | undefined;
   showPageBackground: boolean | undefined;
   fakePosts?: FakePost[];
-  // Posts with bylines resolved server-side. When omitted (client theme
-  // preview) the list is built here and bylines resolve on the client.
+  // Server callers attach bylines before passing these; the client theme
+  // preview passes them byline-less and PublicationPostsList resolves them.
   posts?: PublicationPostsListPost[];
 }) => {
   const newsletterMode = !!publication.publication_newsletter_settings?.enabled;
   // publication_pages rows are published state, so the nav reads them directly.
   const navPages = publishedNavPages(publication.publication_pages);
-  const posts: PublicationPostsListPost[] = fakePosts
-    ? []
-    : (resolvedPosts ??
-      buildPublicationPosts(publication.documents_in_publications));
+  const posts: PublicationPostsListPost[] = fakePosts ? [] : resolvedPosts ?? [];
   return (
     <>
       <FontLoader

--- a/app/(app)/lish/[did]/[publication]/[rkey]/PublicationPageRenderer.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/PublicationPageRenderer.tsx
@@ -20,6 +20,7 @@ import { LeafletContentProvider } from "contexts/LeafletContentContext";
 import { DocumentProvider } from "contexts/DocumentContext";
 import type { DocumentContextValue } from "contexts/DocumentContext";
 import { buildPublicationPosts } from "../buildPublicationPosts";
+import { fetchPublicationPostRows } from "../getPublicationForPage";
 import {
   POSTS_LIST_PAGE_SIZE,
   postsListFilterKey,
@@ -111,12 +112,16 @@ export async function PublicationPageRenderer({
     PubLeafletBlocksPostsList.isMain(b.block),
   );
 
-  // The page query already loaded every document, so build the list in memory.
   // Per distinct tag-filter signature, ship the full ordered URI list plus a
   // byline-resolved first batch (in the SSR HTML); the client hydrates later
-  // batches by URI on scroll via getPostsByUris.
+  // batches by URI on scroll via getPostsByUris. The document list is only
+  // loaded when the page renders one — callers that already have it (theme
+  // preview) pass it in, everyone else defers the query to here.
   const allPosts = postsListBlocks.length
-    ? buildPublicationPosts(publication.documents_in_publications)
+    ? buildPublicationPosts(
+        publication.documents_in_publications ??
+          (await fetchPublicationPostRows(publication.uri)),
+      )
     : [];
   const distinctFilters = new Map<string, string[] | undefined>();
   for (const b of postsListBlocks) {

--- a/app/(app)/lish/[did]/[publication]/[rkey]/PublicationPageRenderer.tsx
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/PublicationPageRenderer.tsx
@@ -101,6 +101,18 @@ export async function PublicationPageRenderer({
       ? [firstPage as PubLeafletPagesLinearDocument.Main]
       : [];
 
+  const postsListBlocks = allBlocks.filter((b) =>
+    PubLeafletBlocksPostsList.isMain(b.block),
+  );
+
+  // The document list is only loaded when the page renders one — callers that
+  // already have it (theme preview) pass it in, everyone else queries here.
+  // Started before the block-resource fetches so the two overlap.
+  const postRowsPromise = postsListBlocks.length
+    ? publication.documents_in_publications ??
+      fetchPublicationPostRows(publication.uri)
+    : [];
+
   const {
     bskyPostData,
     standardSitePostData: standardSitePosts,
@@ -108,21 +120,10 @@ export async function PublicationPageRenderer({
     prerenderedCodeBlocks,
   } = await collectAndFetchBlockResources({ agent, pages: resourcePages });
 
-  const postsListBlocks = allBlocks.filter((b) =>
-    PubLeafletBlocksPostsList.isMain(b.block),
-  );
-
   // Per distinct tag-filter signature, ship the full ordered URI list plus a
   // byline-resolved first batch (in the SSR HTML); the client hydrates later
-  // batches by URI on scroll via getPostsByUris. The document list is only
-  // loaded when the page renders one — callers that already have it (theme
-  // preview) pass it in, everyone else defers the query to here.
-  const allPosts = postsListBlocks.length
-    ? buildPublicationPosts(
-        publication.documents_in_publications ??
-          (await fetchPublicationPostRows(publication.uri)),
-      )
-    : [];
+  // batches by URI on scroll via getPostsByUris.
+  const allPosts = buildPublicationPosts(await postRowsPromise);
   const distinctFilters = new Map<string, string[] | undefined>();
   for (const b of postsListBlocks) {
     const filterByTags = (b.block as PubLeafletBlocksPostsList.Main)

--- a/app/(app)/lish/[did]/[publication]/[rkey]/getPostPageData.ts
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/getPostPageData.ts
@@ -30,7 +30,7 @@ export async function getPostPageData(
         uri,
         comments_on_documents(record),
         documents_in_publications(publications(*,
-          documents_in_publications(documents(uri, data)),
+          documents_in_publications(documents(uri, sort_date, title:data->>title, publishedAt:data->>publishedAt)),
           publication_subscriptions(*),
           publication_newsletter_settings(enabled),
           publication_pages(id, path, title, record_uri, sort_order))
@@ -102,24 +102,16 @@ export async function getPostPageData(
       ?.documents_in_publications;
 
   if (currentPublishedAt && allDocs) {
-    // Filter and sort documents by publishedAt
+    // The publishedAt filter mirrors normalizeDocumentRecord's gating of
+    // unpublished pub.leaflet records without paying for the full data jsonb
+    // of every sibling post.
     const sortedDocs = allDocs
-      .map((dip) => {
-        const normalizedData = normalizeDocumentRecord(
-          dip?.documents?.data,
-          dip?.documents?.uri,
-        );
-        return {
-          uri: dip?.documents?.uri,
-          title: normalizedData?.title,
-          publishedAt: normalizedData?.publishedAt,
-        };
-      })
-      .filter((doc) => doc.publishedAt && doc.title) // Only include docs with publishedAt and valid data
+      .flatMap((dip) => (dip.documents ? [dip.documents] : []))
+      .filter((doc) => doc.publishedAt && doc.title)
       .sort(
         (a, b) =>
-          new Date(a.publishedAt!).getTime() -
-          new Date(b.publishedAt!).getTime(),
+          new Date(a.sort_date || 0).getTime() -
+          new Date(b.sort_date || 0).getTime(),
       );
 
     // Find current document index

--- a/app/(app)/lish/[did]/[publication]/archive/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/archive/page.tsx
@@ -86,11 +86,14 @@ export default async function PublicationArchive(props: {
     path: "/archive",
   });
   if (pageRender) return pageRender;
-  let { data: shadowingDocs } = await supabaseServerClient
-    .from("documents")
-    .select("uri")
-    .or(await resolveDocumentFilter(did, publication_name, "archive"))
-    .limit(1);
+  // The post rows are fetched alongside the shadowing check; they only go
+  // unused in the rare case a document publishes at the /archive path.
+  const [{ data: shadowingDocs }, postRows] = await Promise.all([
+    resolveDocumentFilter(did, publication_name, "archive").then((filter) =>
+      supabaseServerClient.from("documents").select("uri").or(filter).limit(1),
+    ),
+    fetchPublicationPostRows(publication.uri),
+  ]);
   if (shadowingDocs?.[0])
     return (
       <DocumentPageRenderer
@@ -101,10 +104,7 @@ export default async function PublicationArchive(props: {
     );
 
   const record = normalizePublicationRecord(publication.record);
-  const posts = buildPublicationPosts(
-    await fetchPublicationPostRows(publication.uri),
-  )
-    .slice()
+  const posts = buildPublicationPosts(postRows)
     .sort((a, b) => {
       const aDate = a.record.publishedAt
         ? new Date(a.record.publishedAt).getTime()

--- a/app/(app)/lish/[did]/[publication]/archive/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/archive/page.tsx
@@ -19,7 +19,10 @@ import {
 import { DocumentPageRenderer } from "../[rkey]/DocumentPageRenderer";
 import { postPageMetadata } from "../[rkey]/postPageMetadata";
 import { buildPublicationPosts } from "../buildPublicationPosts";
-import { fetchPublicationForPage } from "../getPublicationForPage";
+import {
+  fetchPublicationForPage,
+  fetchPublicationPostRows,
+} from "../getPublicationForPage";
 import { tryRenderPublicationPage } from "../tryRenderPublicationPage";
 import { resolveDocumentFilter } from "../resolveDocumentFilter";
 import { publicationAlternates } from "../publicationAlternates";
@@ -98,7 +101,9 @@ export default async function PublicationArchive(props: {
     );
 
   const record = normalizePublicationRecord(publication.record);
-  const posts = buildPublicationPosts(publication.documents_in_publications)
+  const posts = buildPublicationPosts(
+    await fetchPublicationPostRows(publication.uri),
+  )
     .slice()
     .sort((a, b) => {
       const aDate = a.record.publishedAt

--- a/app/(app)/lish/[did]/[publication]/atom/route.ts
+++ b/app/(app)/lish/[did]/[publication]/atom/route.ts
@@ -17,5 +17,10 @@ export async function GET(
     return feed;
   }
 
-  return feedResponse(req, feed.atom1(), "application/atom+xml");
+  return feedResponse(
+    req,
+    feed.atom1(),
+    "application/atom+xml",
+    feed.options.updated,
+  );
 }

--- a/app/(app)/lish/[did]/[publication]/feedResponse.ts
+++ b/app/(app)/lish/[did]/[publication]/feedResponse.ts
@@ -18,26 +18,20 @@ export function feedResponse(
   lastModified?: Date,
 ) {
   const etag = `"${createHash("sha1").update(body).digest("base64url")}"`;
-  const lastModifiedHeader = lastModified
-    ? { "Last-Modified": lastModified.toUTCString() }
-    : undefined;
-  const headers304 = { ETag: etag, ...lastModifiedHeader, ...CACHE_HEADERS };
-  if (etagMatches(req.headers.get("if-none-match"), etag))
-    return new Response(null, { status: 304, headers: headers304 });
-  // Per RFC 9110 If-Modified-Since only applies when If-None-Match is absent.
-  if (
-    !req.headers.get("if-none-match") &&
-    lastModified &&
-    modifiedSince(req.headers.get("if-modified-since"), lastModified)
-  )
-    return new Response(null, { status: 304, headers: headers304 });
+  const headers = {
+    ETag: etag,
+    ...(lastModified && { "Last-Modified": lastModified.toUTCString() }),
+    ...CACHE_HEADERS,
+  };
+  // Per RFC 9110, If-Modified-Since only applies when If-None-Match is absent.
+  const ifNoneMatch = req.headers.get("if-none-match");
+  const notModified = ifNoneMatch
+    ? etagMatches(ifNoneMatch, etag)
+    : !!lastModified &&
+      modifiedSince(req.headers.get("if-modified-since"), lastModified);
+  if (notModified) return new Response(null, { status: 304, headers });
   return new Response(body, {
-    headers: {
-      "Content-Type": contentType,
-      ETag: etag,
-      ...lastModifiedHeader,
-      ...CACHE_HEADERS,
-    },
+    headers: { "Content-Type": contentType, ...headers },
   });
 }
 

--- a/app/(app)/lish/[did]/[publication]/feedResponse.ts
+++ b/app/(app)/lish/[did]/[publication]/feedResponse.ts
@@ -9,16 +9,35 @@ const CACHE_HEADERS = {
 // and nearly all of them send If-None-Match — but transfer out is billed
 // even on CDN cache hits, so serving the full document to every poll pays
 // for the same unchanged bytes over and over. A content-derived ETag lets
-// an unchanged feed answer with an empty 304 instead.
-export function feedResponse(req: Request, body: string, contentType: string) {
+// an unchanged feed answer with an empty 304 instead. `lastModified` (the
+// newest post's date) covers the readers that only send If-Modified-Since.
+export function feedResponse(
+  req: Request,
+  body: string,
+  contentType: string,
+  lastModified?: Date,
+) {
   const etag = `"${createHash("sha1").update(body).digest("base64url")}"`;
+  const lastModifiedHeader = lastModified
+    ? { "Last-Modified": lastModified.toUTCString() }
+    : undefined;
+  const headers304 = { ETag: etag, ...lastModifiedHeader, ...CACHE_HEADERS };
   if (etagMatches(req.headers.get("if-none-match"), etag))
-    return new Response(null, {
-      status: 304,
-      headers: { ETag: etag, ...CACHE_HEADERS },
-    });
+    return new Response(null, { status: 304, headers: headers304 });
+  // Per RFC 9110 If-Modified-Since only applies when If-None-Match is absent.
+  if (
+    !req.headers.get("if-none-match") &&
+    lastModified &&
+    modifiedSince(req.headers.get("if-modified-since"), lastModified)
+  )
+    return new Response(null, { status: 304, headers: headers304 });
   return new Response(body, {
-    headers: { "Content-Type": contentType, ETag: etag, ...CACHE_HEADERS },
+    headers: {
+      "Content-Type": contentType,
+      ETag: etag,
+      ...lastModifiedHeader,
+      ...CACHE_HEADERS,
+    },
   });
 }
 
@@ -30,4 +49,13 @@ function etagMatches(ifNoneMatch: string | null, etag: string) {
     .split(",")
     .map((t) => t.trim().replace(/^W\//, ""))
     .includes(etag);
+}
+
+function modifiedSince(ifModifiedSince: string | null, lastModified: Date) {
+  if (!ifModifiedSince) return false;
+  const since = new Date(ifModifiedSince).getTime();
+  if (isNaN(since)) return false;
+  // Compare at whole-second granularity — Last-Modified drops milliseconds,
+  // so readers echo back a truncated timestamp.
+  return Math.floor(lastModified.getTime() / 1000) <= Math.floor(since / 1000);
 }

--- a/app/(app)/lish/[did]/[publication]/generateFeed.ts
+++ b/app/(app)/lish/[did]/[publication]/generateFeed.ts
@@ -61,11 +61,7 @@ export async function generateFeed(
   );
   let { data: publications, error } = await supabaseServerClient
     .from("publications")
-    .select(
-      `*,
-      documents_in_publications(documents(*))
-      `,
-    )
+    .select(`uri, record`)
     .eq("identity_did", did)
     .or(publicationNameOrUriFilter(did, publication_name))
     .order("uri", { ascending: false })
@@ -97,19 +93,23 @@ export async function generateFeed(
   );
   const description = pubRecord?.description ?? rawRecord?.description;
 
-  let docs = publication.documents_in_publications
-    .sort((a, b) => {
-      const dateA = a.documents?.sort_date
-        ? new Date(a.documents.sort_date).getTime()
-        : 0;
-      const dateB = b.documents?.sort_date
-        ? new Date(b.documents.sort_date).getTime()
-        : 0;
-      return dateB - dateA; // Sort in descending order (newest first)
-    })
-    .slice(0, FEED_ITEM_LIMIT);
+  let { data: docs, error: docsError } = await supabaseServerClient
+    .from("documents")
+    .select(
+      `uri, data, sort_date,
+       documents_in_publications!inner(publication)`,
+    )
+    .eq("documents_in_publications.publication", publication.uri)
+    .order("sort_date", { ascending: false })
+    .order("uri", { ascending: false })
+    .limit(FEED_ITEM_LIMIT);
+  if (docsError) {
+    console.error(docsError);
+    return new NextResponse(null, { status: 500 });
+  }
+  docs = docs ?? [];
 
-  const newest = parseDate(docs[0]?.documents?.sort_date);
+  const newest = parseDate(docs[0]?.sort_date);
 
   const feed = new Feed({
     title: stripInvalidXmlChars(name),
@@ -134,12 +134,8 @@ export async function generateFeed(
   });
 
   for (const doc of docs) {
-    if (!doc.documents) continue;
-    const record = normalizeDocumentRecord(
-      doc.documents?.data,
-      doc.documents?.uri,
-    );
-    const uri = new AtUri(doc.documents?.uri);
+    const record = normalizeDocumentRecord(doc.data, doc.uri);
+    const uri = new AtUri(doc.uri);
     if (!record) continue;
 
     let blocks: PubLeafletPagesLinearDocument.Block[] = [];
@@ -151,7 +147,7 @@ export async function generateFeed(
     }
 
     const docUrl = absolutize(
-      getDocumentURL(record, doc.documents.uri, pubRecord ?? pubInput),
+      getDocumentURL(record, doc.uri, pubRecord ?? pubInput),
     );
 
     let content: string;
@@ -176,9 +172,7 @@ export async function generateFeed(
     }
 
     const date =
-      parseDate(record.publishedAt) ??
-      parseDate(doc.documents.sort_date) ??
-      new Date(0);
+      parseDate(record.publishedAt) ?? parseDate(doc.sort_date) ?? new Date(0);
 
     feed.addItem({
       title: stripInvalidXmlChars(record.title || ""),

--- a/app/(app)/lish/[did]/[publication]/generateFeed.ts
+++ b/app/(app)/lish/[did]/[publication]/generateFeed.ts
@@ -56,7 +56,8 @@ export async function generateFeed(
   did: string,
   publication_name: string,
 ): Promise<Feed | NextResponse<unknown>> {
-  let renderToReadableStream = await import("react-dom/server").then(
+  // Started before the queries so the module load (cold starts) overlaps them.
+  let renderToReadableStreamPromise = import("react-dom/server").then(
     (module) => module.renderToReadableStream,
   );
   let { data: publications, error } = await supabaseServerClient
@@ -133,6 +134,7 @@ export async function generateFeed(
     },
   });
 
+  const renderToReadableStream = await renderToReadableStreamPromise;
   for (const doc of docs) {
     const record = normalizeDocumentRecord(doc.data, doc.uri);
     const uri = new AtUri(doc.uri);

--- a/app/(app)/lish/[did]/[publication]/getPublicationForPage.ts
+++ b/app/(app)/lish/[did]/[publication]/getPublicationForPage.ts
@@ -10,11 +10,7 @@ export async function fetchPublicationForPage(
     .select(
       `uri, name, identity_did, record,
        publication_newsletter_settings(enabled),
-       publication_pages(id, path, title, record, record_uri, sort_order),
-       documents_in_publications(documents(uri, data,
-         comments_on_documents(count),
-         document_mentions_in_bsky(count),
-         recommends_on_documents(count)))`,
+       publication_pages(id, path, title, record, record_uri, sort_order)`,
     )
     .eq("identity_did", did)
     .or(publicationNameOrUriFilter(did, publicationName))
@@ -26,3 +22,20 @@ export async function fetchPublicationForPage(
 export type PublicationForPage = NonNullable<
   Awaited<ReturnType<typeof fetchPublicationForPage>>
 >;
+
+// Fetched separately from the publication row because most requests through
+// fetchPublicationForPage (every post URL, any page without a posts list)
+// never render the post list — loading every document's full record jsonb up
+// front made the common path pay for the rare one.
+export async function fetchPublicationPostRows(publicationUri: string) {
+  const { data } = await supabaseServerClient
+    .from("documents_in_publications")
+    .select(
+      `documents(uri, data,
+         comments_on_documents(count),
+         document_mentions_in_bsky(count),
+         recommends_on_documents(count))`,
+    )
+    .eq("publication", publicationUri);
+  return data ?? [];
+}

--- a/app/(app)/lish/[did]/[publication]/json/route.ts
+++ b/app/(app)/lish/[did]/[publication]/json/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { generateFeed } from "../generateFeed";
+import { feedResponse } from "../feedResponse";
 
 export async function GET(
   req: Request,
@@ -16,11 +17,10 @@ export async function GET(
     return feed;
   }
 
-  return new Response(feed.json1(), {
-    headers: {
-      "Content-Type": "application/feed+json",
-      "Cache-Control": "s-maxage=300, stale-while-revalidate=3600",
-      "CDN-Cache-Control": "s-maxage=300, stale-while-revalidate=3600",
-    },
-  });
+  return feedResponse(
+    req,
+    feed.json1(),
+    "application/feed+json",
+    feed.options.updated,
+  );
 }

--- a/app/(app)/lish/[did]/[publication]/layout.tsx
+++ b/app/(app)/lish/[did]/[publication]/layout.tsx
@@ -22,12 +22,7 @@ export async function generateMetadata(props: {
   let publication_name = decodeURIComponent(params.publication);
   let { data: publications } = await supabaseServerClient
     .from("publications")
-    .select(
-      `*,
-        publication_subscriptions(*),
-      documents_in_publications(documents(*))
-      `,
-    )
+    .select(`uri, record`)
     .eq("identity_did", did)
     .or(publicationNameOrUriFilter(did, publication_name))
     .order("uri", { ascending: false })

--- a/app/(app)/lish/[did]/[publication]/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/page.tsx
@@ -8,7 +8,10 @@ import { normalizePublicationRecord } from "src/utils/normalizeRecords";
 import { publicationAlternates } from "./publicationAlternates";
 import { DefaultPublicationHomepage } from "./DefaultPublicationHomepage";
 import { buildPublicationPosts } from "./buildPublicationPosts";
-import { fetchPublicationForPage } from "./getPublicationForPage";
+import {
+  fetchPublicationForPage,
+  fetchPublicationPostRows,
+} from "./getPublicationForPage";
 import { tryRenderPublicationPage } from "./tryRenderPublicationPage";
 import { getProfiles } from "src/identity";
 import { attachBylineProfiles, bylineDidsForPosts } from "src/utils/byline";
@@ -65,7 +68,7 @@ export default async function Publication(props: {
     // SSR HTML.
     const agent = new BskyAgent({ service: "https://public.api.bsky.app" });
     const homepagePosts = buildPublicationPosts(
-      publication.documents_in_publications,
+      await fetchPublicationPostRows(publication.uri),
     );
     const [{ data: profile }, bylineProfiles] = await Promise.all([
       agent.getProfile({ actor: did }),

--- a/app/(app)/lish/[did]/[publication]/page.tsx
+++ b/app/(app)/lish/[did]/[publication]/page.tsx
@@ -65,14 +65,18 @@ export default async function Publication(props: {
 
     const record = normalizePublicationRecord(publication.record);
     // Resolve the author profile and post bylines server-side so they're in the
-    // SSR HTML.
+    // SSR HTML. The profile lookup is independent of the post queries, so it
+    // runs alongside the rows → bylines chain.
     const agent = new BskyAgent({ service: "https://public.api.bsky.app" });
-    const homepagePosts = buildPublicationPosts(
-      await fetchPublicationPostRows(publication.uri),
-    );
-    const [{ data: profile }, bylineProfiles] = await Promise.all([
+    const [{ data: profile }, posts] = await Promise.all([
       agent.getProfile({ actor: did }),
-      getProfiles(bylineDidsForPosts(homepagePosts)),
+      fetchPublicationPostRows(publication.uri).then(async (rows) => {
+        const posts = buildPublicationPosts(rows);
+        return attachBylineProfiles(
+          posts,
+          await getProfiles(bylineDidsForPosts(posts)),
+        );
+      }),
     ]);
     return (
       <PublicationThemeProvider
@@ -89,7 +93,7 @@ export default async function Publication(props: {
             did={did}
             profile={profile}
             showPageBackground={record?.theme?.showPageBackground}
-            posts={attachBylineProfiles(homepagePosts, bylineProfiles)}
+            posts={posts}
           />
         </PublicationBackgroundProvider>
       </PublicationThemeProvider>

--- a/app/(app)/lish/[did]/[publication]/rss/route.ts
+++ b/app/(app)/lish/[did]/[publication]/rss/route.ts
@@ -21,5 +21,6 @@ export async function GET(
     req,
     collapseInterTagWhitespace(feed.rss2()),
     "application/rss+xml",
+    feed.options.updated,
   );
 }

--- a/app/(app)/lish/[did]/[publication]/theme-settings/PubPreview.tsx
+++ b/app/(app)/lish/[did]/[publication]/theme-settings/PubPreview.tsx
@@ -7,6 +7,7 @@ import {
 import { useIdentityData } from "components/IdentityProvider";
 import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 import { DefaultPublicationHomepage } from "../DefaultPublicationHomepage";
+import { buildPublicationPosts } from "../buildPublicationPosts";
 import { LocalizedDate } from "../LocalizedDate";
 import type { ReactNode } from "react";
 
@@ -100,6 +101,7 @@ export function PubPreview(props: {
       profile={profile}
       showPageBackground={props.showPageBackground}
       fakePosts={fakePosts}
+      posts={buildPublicationPosts(publication.documents_in_publications)}
     />
   );
 }

--- a/app/(app)/lish/feeds/[...path]/route.ts
+++ b/app/(app)/lish/feeds/[...path]/route.ts
@@ -2,10 +2,6 @@ import { NextResponse } from "next/server";
 import { DidResolver } from "@atproto/identity";
 import { parseReqNsid, verifyJwt } from "@atproto/xrpc-server";
 import { supabaseServerClient } from "supabase/serverClient";
-import {
-  normalizeDocumentRecord,
-  type NormalizedDocument,
-} from "src/utils/normalizeRecords";
 
 const serviceDid = "did:web:leaflet.pub:lish:feeds";
 export async function GET(
@@ -27,19 +23,29 @@ export async function GET(
     });
   let auth = validateAuth(req, serviceDid);
   if (!auth) return NextResponse.json({}, { status: 301 });
+  // The skeleton only needs the bsky post ref out of each document, so
+  // project just the refs instead of the full record jsonb. postRef is the
+  // pub.leaflet field, bskyPostRef the site.standard one; publishedAt gates
+  // pub.leaflet records the same way normalizeDocument does.
   let { data: publications } = await supabaseServerClient
     .from("publication_subscriptions")
-    .select(`publications(documents_in_publications(documents(*)))`)
+    .select(
+      `publications(documents_in_publications(documents(
+         postRef:data->postRef, bskyPostRef:data->bskyPostRef, publishedAt:data->>publishedAt)))`,
+    )
     .eq("identity", auth);
   return NextResponse.json({
     feed: [
       ...(publications || []).flatMap((pub) => {
         let posts = pub.publications?.documents_in_publications || [];
         return posts.flatMap((p) => {
-          if (!p.documents?.data) return [];
-          const normalizedDoc = normalizeDocumentRecord(p.documents.data, p.documents.uri);
-          if (!normalizedDoc?.bskyPostRef) return [];
-          return { post: normalizedDoc.bskyPostRef.uri };
+          if (!p.documents) return [];
+          let ref = (p.documents.bskyPostRef ??
+            (p.documents.publishedAt ? p.documents.postRef : null)) as {
+            uri?: string;
+          } | null;
+          if (!ref?.uri) return [];
+          return { post: ref.uri };
         });
       }),
     ],


### PR DESCRIPTION
## Summary

This PR optimizes feed generation and publication page queries by:

1. **Splitting document queries** - Separates the initial publication fetch from document loading, allowing queries to run in parallel and avoiding unnecessary full-document loads on pages that don't render post lists
2. **Reducing data transfer** - Projects only needed fields (uri, record, sort_date, etc.) instead of loading full document jsonb for every query
3. **Improving cache efficiency** - Adds `Last-Modified` header support to feed responses alongside ETags, allowing clients that only send `If-Modified-Since` to receive 304 responses
4. **Overlapping module loads** - Starts the `react-dom/server` import before database queries on cold starts to reduce latency

## Changes

### Feed Generation (`generateFeed.ts`)
- Start `renderToReadableStream` import before queries to overlap module loading
- Reduce publication query to just `uri, record` fields
- Move document fetching to a separate query that projects only needed fields and applies sorting/limiting at the database level
- Simplify document access patterns (remove nested `documents_in_publications` navigation)

### Feed Response Caching (`feedResponse.ts`)
- Add `lastModified` parameter to support `If-Modified-Since` header
- Implement `modifiedSince()` function for RFC 9110 compliant conditional request handling
- Return 304 responses for both ETag and Last-Modified matches

### Publication Pages
- Extract `fetchPublicationPostRows()` helper to load documents separately from publication metadata
- Update `page.tsx`, `archive/page.tsx`, and `PublicationPageRenderer.tsx` to fetch post rows only when needed
- Parallelize profile and post row fetches where possible
- Remove `documents_in_publications` from publication queries in `layout.tsx` and `getPublicationForPage.ts`

### Feed Routes
- Pass `feed.options.updated` to `feedResponse()` for Last-Modified header in JSON, Atom, and RSS feeds
- Update `feeds/[...path]/route.ts` to project only `postRef`, `bskyPostRef`, and `publishedAt` fields

### Post Page Data (`getPostPageData.ts`)
- Simplify document sorting to use `sort_date` instead of parsing full records
- Project only needed fields from the documents query

## Testing

- Verified feed responses include proper ETag and Last-Modified headers
- Confirmed 304 responses work for both If-None-Match and If-Modified-Since requests
- Existing tests pass; no new test coverage needed for query optimization

## Checklist

- [x] No build errors
- [x] Queries optimized to reduce data transfer
- [x] Feed caching improved with Last-Modified support
- [x] Post list loading deferred until actually needed

https://claude.ai/code/session_017w9GceB5kdYvDiZtgEnsGL