### PR TITLE
AT meta tags

### DIFF
--- a/app/(app)/lish/[did]/[publication]/[rkey]/postPageMetadata.ts
+++ b/app/(app)/lish/[did]/[publication]/[rkey]/postPageMetadata.ts
@@ -67,6 +67,9 @@ export async function postPageMetadata(props: {
   // compete with the custom-domain version in search results.
   let canonical: string | undefined;
   let feedTypes: Record<string, string> | undefined;
+  let other: Metadata["other"] = {
+    "at:canonical": document.uri,
+  };
   if (publication) {
     let url = getDocumentURL(docRecord, document.uri, publication);
     if (url.startsWith("http")) canonical = url;
@@ -78,6 +81,7 @@ export async function postPageMetadata(props: {
         "application/feed+json": `${pubRecord.url}/json`,
       };
     }
+    other["at:alternate"] = publication.uri;
   }
 
   return {
@@ -105,5 +109,6 @@ export async function postPageMetadata(props: {
       " - " +
       document.documents_in_publications[0]?.publications?.name,
     description: docRecord?.description || "",
+    other,
   };
 }

--- a/app/(app)/lish/[did]/[publication]/layout.tsx
+++ b/app/(app)/lish/[did]/[publication]/layout.tsx
@@ -64,5 +64,8 @@ export async function generateMetadata(props: {
           },
         }
       : undefined,
+    other: {
+      "at:canonical": publication.uri,
+    },
   };
 }

--- a/app/(app)/p/[didOrHandle]/[rkey]/page.tsx
+++ b/app/(app)/p/[didOrHandle]/[rkey]/page.tsx
@@ -57,6 +57,9 @@ export async function generateMetadata(props: {
     },
     title: docRecord.title,
     description: docRecord?.description || "",
+    other: {
+      "at:canonical": document.uri,
+    },
   };
 }
 


### PR DESCRIPTION
This PR implements the [community proposal](https://tangled.org/chrisshank.com/at-tags/) for mapping web pages back AT URIs. It precends #365.

As for standard.site using the new proposal I'm thinking that it would look like this. I think the first step is to get the big 3 to start publishing these tags.

```html
<meta name="at:canonical" content="at://did:plc:xyz789/site.standard.document/rkey" />
<meta name="at:alternate" content="at://did:plc:abc123/site.standard.publication/rkey" />
```
