### PR TITLE
fix inline footnote numbering restarting at 1 in every block

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -629,6 +629,12 @@ body.cmd-held .ProseMirror a {
 .footnote-scope {
   counter-reset: footnote;
 }
+/* A page link renders the linked page's own text (its first lines and the
+   thumbnail), footnote refs included. Those belong to the other page, so give
+   them a counter of their own rather than letting them advance this page's. */
+.pageLinkBlockWrapper {
+  counter-reset: footnote;
+}
 .footnote-ref {
   counter-increment: footnote;
   cursor: pointer;

--- a/components/Footnotes/FootnotePopover.tsx
+++ b/components/Footnotes/FootnotePopover.tsx
@@ -41,7 +41,9 @@ export function FootnotePopover() {
     if (!anchorElement || !footnote) return footnote?.index ?? 0;
     let container = anchorElement.closest(".footnote-scope");
     if (!container) return footnote.index;
-    let allRefs = Array.from(container.querySelectorAll(".footnote-ref"));
+    let allRefs = Array.from(
+      container.querySelectorAll(".footnote-ref"),
+    ).filter((ref) => !ref.closest(".pageLinkBlockWrapper"));
     let pos = allRefs.indexOf(anchorElement);
     return pos >= 0 ? pos + 1 : footnote.index;
   }, [anchorElement, footnote]);

--- a/components/Pages/Page.tsx
+++ b/components/Pages/Page.tsx
@@ -145,8 +145,14 @@ export const PageWrapper = (props: {
         ref={ref}
         onClick={props.onClickAction}
         id={props.id}
+        // footnote-scope (the counter-reset the inline footnote numbers count
+        // from) has to sit here rather than on the contents div below: that div
+        // is display:contents in the card-border layout, and counter properties
+        // on a box-less element are ignored, so every block started its own
+        // counter and inline refs all rendered as 1.
         className={`
       pageScrollWrapper
+      footnote-scope
       publicationScrollContainer
       grow relative
       shrink-0 snap-center
@@ -171,7 +177,7 @@ export const PageWrapper = (props: {
 `}
       >
         <div
-          className={`postPageContent footnote-scope static
+          className={`postPageContent static
           ${props.fullPageScroll ? "h-full sm:max-w-[var(--page-width-units)] mx-auto" : ` contents w-full ${props.flow ? "" : "h-full"}`}
         `}
         >


### PR DESCRIPTION
The inline footnote number is a CSS counter: .footnote-scope resets it,
.footnote-ref increments it and prints it in ::after. The scope class sat
on the postPageContent div, which is display:contents in the card-border
editor layout — an element that generates no box, so its counter-reset is
ignored. With no counter in scope, each .footnote-ref created its own
counter (scoped to itself and its following siblings), so every block
restarted at 1 while the side column and end-of-document section, which
number from the data model, stayed correct. Move the scope to the
pageScrollWrapper, which is always a real box.

Also stop page-link blocks from advancing the page's counter: they render
the linked page's first lines and thumbnail, footnote refs included, which
shifted every inline number after them. They get their own counter now,
and the popover's DOM-order index skips them to match.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EkZBqxUsJMjN3YvNFAGGB4