### PR TITLE
Support full text decorations in footnotes

### DIFF
--- a/components/Blocks/TextBlock/inputRules.ts
+++ b/components/Blocks/TextBlock/inputRules.ts
@@ -23,106 +23,115 @@ const anchorInCodeMark = (state: EditorState, start: number, end: number) => {
   const endMarks = state.doc.resolve(end).marks();
   return !!codeMark.isInSet(startMarks) || !!codeMark.isInSet(endMarks);
 };
+
+// Inline text-decoration markdown shortcuts (bold, italic, code, strikethrough,
+// highlight). Shared with the footnote editor so it accepts the same syntax as
+// the main text block — see footnoteInputRules below.
+export const inlineMarkInputRules = (): InputRule[] => [
+  //Strikethrough
+  new InputRule(/\~\~([^*]+)\~\~$/, (state, match, start, end) => {
+    if (anchorInCodeMark(state, start, end)) return null;
+    const [fullMatch, content] = match;
+    const { tr } = state;
+    if (content) {
+      tr.replaceWith(start, end, state.schema.text(content))
+        .addMark(
+          start,
+          start + content.length,
+          schema.marks.strikethrough.create(),
+        )
+        .removeStoredMark(schema.marks.strikethrough);
+      return tr;
+    }
+    return null;
+  }),
+
+  //Highlight
+  new InputRule(/\=\=([^*]+)\=\=$/, (state, match, start, end) => {
+    if (anchorInCodeMark(state, start, end)) return null;
+    const [fullMatch, content] = match;
+    const { tr } = state;
+    if (content) {
+      tr.replaceWith(start, end, state.schema.text(content))
+        .addMark(
+          start,
+          start + content.length,
+          schema.marks.highlight.create({
+            color: useUIState.getState().lastUsedHighlight || "1",
+          }),
+        )
+        .removeStoredMark(schema.marks.highlight);
+      return tr;
+    }
+    return null;
+  }),
+
+  //Bold
+  new InputRule(/\*\*([^*]+)\*\*$/, (state, match, start, end) => {
+    if (anchorInCodeMark(state, start, end)) return null;
+    const [fullMatch, content] = match;
+    const { tr } = state;
+    if (content) {
+      tr.replaceWith(start, end, state.schema.text(content))
+        .addMark(start, start + content.length, schema.marks.strong.create())
+        .removeStoredMark(schema.marks.strong);
+      return tr;
+    }
+    return null;
+  }),
+
+  //Code
+  new InputRule(/\`([^`]+)\`$/, (state, match, start, end) => {
+    if (anchorInCodeMark(state, start, end)) return null;
+    const [fullMatch, content] = match;
+    const { tr } = state;
+    if (content) {
+      const startIndex = start + fullMatch.indexOf("`");
+      tr.replaceWith(startIndex, end, state.schema.text(content))
+        .addMark(
+          startIndex,
+          startIndex + content.length,
+          schema.marks.code.create(),
+        )
+        .removeStoredMark(schema.marks.code);
+      return tr;
+    }
+    return null;
+  }),
+
+  //Italic
+  new InputRule(/(?:^|[^*])\*([^*]+)\*$/, (state, match, start, end) => {
+    if (anchorInCodeMark(state, start, end)) return null;
+    const [fullMatch, content] = match;
+    const { tr } = state;
+    if (content) {
+      const startIndex = start + fullMatch.indexOf("*");
+      tr.replaceWith(startIndex, end, state.schema.text(content))
+        .addMark(
+          startIndex,
+          startIndex + content.length,
+          schema.marks.em.create(),
+        )
+        .removeStoredMark(schema.marks.em);
+      return tr;
+    }
+    return null;
+  }),
+];
+
+// Footnotes hold inline content only, so they get the mark shortcuts without any
+// of the block-level rules (lists, headings, code blocks, nested footnotes).
+export const footnoteInputRules = () =>
+  inputRules({ rules: inlineMarkInputRules() });
+
 export const inputrules = (
   propsRef: MutableRefObject<BlockProps & { entity_set: { set: string } }>,
   repRef: MutableRefObject<Replicache<ReplicacheMutators> | null>,
   openMentionAutocomplete?: () => void,
 ) =>
   inputRules({
-    //Strikethrough
     rules: [
-      new InputRule(/\~\~([^*]+)\~\~$/, (state, match, start, end) => {
-        if (anchorInCodeMark(state, start, end)) return null;
-        const [fullMatch, content] = match;
-        const { tr } = state;
-        if (content) {
-          tr.replaceWith(start, end, state.schema.text(content))
-            .addMark(
-              start,
-              start + content.length,
-              schema.marks.strikethrough.create(),
-            )
-            .removeStoredMark(schema.marks.strikethrough);
-          return tr;
-        }
-        return null;
-      }),
-
-      //Highlight
-      new InputRule(/\=\=([^*]+)\=\=$/, (state, match, start, end) => {
-        if (anchorInCodeMark(state, start, end)) return null;
-        const [fullMatch, content] = match;
-        const { tr } = state;
-        if (content) {
-          tr.replaceWith(start, end, state.schema.text(content))
-            .addMark(
-              start,
-              start + content.length,
-              schema.marks.highlight.create({
-                color: useUIState.getState().lastUsedHighlight || "1",
-              }),
-            )
-            .removeStoredMark(schema.marks.highlight);
-          return tr;
-        }
-        return null;
-      }),
-
-      //Bold
-      new InputRule(/\*\*([^*]+)\*\*$/, (state, match, start, end) => {
-        if (anchorInCodeMark(state, start, end)) return null;
-        const [fullMatch, content] = match;
-        const { tr } = state;
-        if (content) {
-          tr.replaceWith(start, end, state.schema.text(content))
-            .addMark(
-              start,
-              start + content.length,
-              schema.marks.strong.create(),
-            )
-            .removeStoredMark(schema.marks.strong);
-          return tr;
-        }
-        return null;
-      }),
-
-      //Code
-      new InputRule(/\`([^`]+)\`$/, (state, match, start, end) => {
-        if (anchorInCodeMark(state, start, end)) return null;
-        const [fullMatch, content] = match;
-        const { tr } = state;
-        if (content) {
-          const startIndex = start + fullMatch.indexOf("`");
-          tr.replaceWith(startIndex, end, state.schema.text(content))
-            .addMark(
-              startIndex,
-              startIndex + content.length,
-              schema.marks.code.create(),
-            )
-            .removeStoredMark(schema.marks.code);
-          return tr;
-        }
-        return null;
-      }),
-
-      //Italic
-      new InputRule(/(?:^|[^*])\*([^*]+)\*$/, (state, match, start, end) => {
-        if (anchorInCodeMark(state, start, end)) return null;
-        const [fullMatch, content] = match;
-        const { tr } = state;
-        if (content) {
-          const startIndex = start + fullMatch.indexOf("*");
-          tr.replaceWith(startIndex, end, state.schema.text(content))
-            .addMark(
-              startIndex,
-              startIndex + content.length,
-              schema.marks.em.create(),
-            )
-            .removeStoredMark(schema.marks.em);
-          return tr;
-        }
-        return null;
-      }),
+      ...inlineMarkInputRules(),
 
       // Code Block
       new InputRule(/^```\s$/, (state, match) => {

--- a/components/Footnotes/FootnoteEditor.tsx
+++ b/components/Footnotes/FootnoteEditor.tsx
@@ -5,6 +5,9 @@ import { baseKeymap, toggleMark } from "prosemirror-commands";
 import { keymap } from "prosemirror-keymap";
 import { ySyncPlugin } from "y-prosemirror";
 import { schema } from "components/Blocks/TextBlock/schema";
+import { formattingKeymap } from "src/utils/prosemirror/formattingKeymap";
+import { footnoteInputRules } from "components/Blocks/TextBlock/inputRules";
+import { highlightSelectionPlugin } from "components/Blocks/TextBlock/plugins";
 import { stripCommentMarks } from "components/Blocks/TextBlock/stripCommentMarks";
 import { useReplicache, useEntity } from "src/replicache";
 import { scanIndex } from "src/replicache/utils";
@@ -86,12 +89,11 @@ function EditableFootnote(props: {
       ySyncPlugin(value),
       cursorPlugin,
       keymap({
-        "Meta-b": toggleMark(schema.marks.strong),
-        "Ctrl-b": toggleMark(schema.marks.strong),
-        "Meta-u": toggleMark(schema.marks.underline),
-        "Ctrl-u": toggleMark(schema.marks.underline),
-        "Meta-i": toggleMark(schema.marks.em),
-        "Ctrl-i": toggleMark(schema.marks.em),
+        ...formattingKeymap(schema.marks),
+        "Ctrl-Meta-h": (...args) =>
+          toggleMark(schema.marks.highlight, {
+            color: useUIState.getState().lastUsedHighlight,
+          })(...args),
         "Shift-Enter": (state, dispatch) => {
           let hardBreak = schema.nodes.hard_break.create();
           if (dispatch) {
@@ -130,7 +132,9 @@ function EditableFootnote(props: {
           return true;
         },
       }),
+      footnoteInputRules(),
       keymap(baseKeymap),
+      highlightSelectionPlugin,
       autolink({
         type: schema.marks.link,
         shouldAutoLink: () => true,

--- a/components/Toolbar/FootnoteTextToolbar.tsx
+++ b/components/Toolbar/FootnoteTextToolbar.tsx
@@ -1,12 +1,14 @@
 import { Separator } from "components/Layout";
 import { LinkButton } from "./InlineLinkToolbar";
 import { TextMarkButtons } from "./TextToolbar";
+import { HighlightButton } from "./HighlightToolbar";
 export const FootnoteTextToolbar = (props: {
-  setToolbarState: (s: "default" | "link") => void;
+  setToolbarState: (s: "default" | "link" | "highlight") => void;
 }) => {
   return (
     <>
       <TextMarkButtons />
+      <HighlightButton setToolbarState={props.setToolbarState} />
       <Separator classname="h-6!" />
       <LinkButton setToolbarState={props.setToolbarState} />
     </>

--- a/components/Toolbar/FootnoteToolbarWrapper.tsx
+++ b/components/Toolbar/FootnoteToolbarWrapper.tsx
@@ -7,11 +7,12 @@ import { useUIState } from "src/useUIState";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { addShortcut } from "src/shortcuts";
 import { FootnoteTextToolbar } from "./FootnoteTextToolbar";
+import { HighlightToolbar } from "./HighlightToolbar";
 import { useIsMobile } from "src/hooks/isMobile";
 import { CloseTiny } from "components/Icons/CloseTiny";
 import { ToolbarPageTypeProvider } from ".";
 
-type FootnoteToolbarState = "default" | "link";
+type FootnoteToolbarState = "default" | "link" | "highlight";
 
 export const FootnoteToolbar = (props: { pageID: string }) => {
   let [toolbarState, setToolbarState] =
@@ -42,6 +43,11 @@ export const FootnoteToolbar = (props: { pageID: string }) => {
         <div className="toolbarOptions flex gap-1 sm:gap-[6px] items-center grow">
           {toolbarState === "default" ? (
             <FootnoteTextToolbar setToolbarState={setToolbarState} />
+          ) : toolbarState === "highlight" ? (
+            <HighlightToolbar
+              pageID={props.pageID}
+              onClose={() => setToolbarState("default")}
+            />
           ) : toolbarState === "link" ? (
             <InlineLinkToolbar
               onClose={() => {


### PR DESCRIPTION
Bring footnote editing to parity with the main text block editor for
inline text decorations:

- Markdown input rules: extract the inline mark shortcuts (bold, italic,
  code, strikethrough, highlight) into a shared inlineMarkInputRules() and
  wire them into the footnote editor via footnoteInputRules(). Block-level
  rules (lists, headings, code blocks, nested footnotes, mentions) stay
  out since footnotes hold inline content only.
- Keyboard shortcuts: use the shared formattingKeymap (bold/italic/
  underline/strikethrough) plus Ctrl-Meta-h for highlight.
- Toolbar: add the Highlight button and highlight sub-toolbar to the
  footnote toolbar, and add the selection-highlight plugin so the
  selection stays visible while the highlight toolbar is open.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013UqX7y4nr8BxVFHRQSnzBJ