### PR TITLE
bust every cached surface a publish changes

### DIFF
--- a/actions/publishToPublication.ts
+++ b/actions/publishToPublication.ts
@@ -1,7 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
-import { revalidatePostPaths } from "src/utils/revalidatePublication";
+import { revalidateDocumentPaths } from "src/utils/revalidatePublication";
 import { restoreOAuthSession, OAuthSessionError } from "src/atproto-oauth";
 import { getAuthIdentity } from "src/auth";
 import {
@@ -38,7 +37,6 @@ import {
 } from "src/membership";
 import {
   normalizeDocumentRecord,
-  normalizePublicationRecord,
   type NormalizedDocument,
 } from "src/utils/normalizeRecords";
 import {
@@ -487,23 +485,10 @@ export async function publishToPublication({
     }
   }
 
-  // The standalone view exists for every published document, publication or
-  // not.
-  revalidatePath(`/p/${credentialSession.did}/${rkey}`);
-  if (publication_uri) {
-    const { data: pubRow } = await supabaseServerClient
-      .from("publications")
-      .select("record")
-      .eq("uri", publication_uri)
-      .maybeSingle();
-    const docPath = (record as { path?: string }).path;
-    revalidatePostPaths(
-      publication_uri,
-      normalizePublicationRecord(pubRow?.record)?.name,
-      rkey,
-      docPath,
-    );
-  }
+  // Runs after the documents/join-row writes above so the re-render reads the
+  // record this publish just wrote — including the title and description that
+  // the post's page metadata is built from.
+  await revalidateDocumentPaths(result.uri);
 
   return { success: true, rkey, record: JSON.parse(JSON.stringify(record)) };
 }

--- a/app/(app)/(identity)/[leaflet_id]/publish/PublishPost.tsx
+++ b/app/(app)/(identity)/[leaflet_id]/publish/PublishPost.tsx
@@ -117,6 +117,23 @@ const PublishPostForm = (
   let params = useParams();
   let { rep } = useReplicache();
 
+  // Title and description come from Replicache, the same source the editor's
+  // Update button uses. The server props were captured when this page rendered,
+  // and the router cache can serve that payload across an edit — publishing
+  // from it would write a title the author already changed.
+  let replicacheTitle = useSubscribe(rep, (tx) =>
+    tx.get<string>("publication_title"),
+  );
+  let replicacheDescription = useSubscribe(rep, (tx) =>
+    tx.get<string>("publication_description"),
+  );
+  let title =
+    typeof replicacheTitle === "string" ? replicacheTitle : props.title;
+  let description =
+    typeof replicacheDescription === "string"
+      ? replicacheDescription
+      : props.description;
+
   // For publications with drafts, use Replicache; otherwise use local state
   let replicacheTags = useSubscribe(rep, (tx) =>
     tx.get<string[]>("publication_tags"),
@@ -183,8 +200,8 @@ const PublishPostForm = (
       root_entity: props.root_entity,
       publication_uri: props.publication_uri,
       leaflet_id: props.leaflet_id,
-      title: props.title,
-      description: props.description,
+      title,
+      description,
       tags: currentTags,
       entitiesToDelete: props.entitiesToDelete,
       publishedAt: localPublishedAt?.toISOString() || new Date().toISOString(),
@@ -295,8 +312,8 @@ const PublishPostForm = (
                   <StandardSiteExternalEmbed
                     external={{
                       uri: props.pubRecord?.url ?? "",
-                      title: props.title || "Untitled",
-                      description: props.description,
+                      title: title || "Untitled",
+                      description: description,
                       thumb: coverImageSrc || undefined,
                       source: {
                         uri: props.pubRecord?.url,
@@ -351,10 +368,10 @@ const PublishPostForm = (
                 charCount={charCount}
                 setCharCount={setCharCount}
                 editorStateRef={editorStateRef}
-                title={props.title}
+                title={title}
                 viewerProfile={props.viewerProfile}
                 publicationOwnerProfile={props.publicationOwnerProfile}
-                description={props.description}
+                description={description}
                 pubRecord={props.pubRecord}
                 newsletter_enabled={props.newsletter_enabled}
                 subscriberCount={props.subscriberCount}

--- a/app/(app)/(published)/p/[didOrHandle]/[rkey]/l-quote/[quote]/page.tsx
+++ b/app/(app)/(published)/p/[didOrHandle]/[rkey]/l-quote/[quote]/page.tsx
@@ -1,6 +1,7 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { decodeQuotePosition } from "src/utils/quotePosition";
-import PostPage from "app/(app)/(published)/p/[didOrHandle]/[rkey]/page";
+import { DocumentPageRenderer } from "app/(app)/(published)/lish/[did]/[publication]/[rkey]/DocumentPageRenderer";
+import { resolveDid } from "app/(app)/(published)/p/[didOrHandle]/resolveDid";
 
 // On-demand ISR: rendered on first request, then served from the CDN and
 // re-rendered in the background. The empty generateStaticParams is what opts a
@@ -17,8 +18,27 @@ export { generateMetadata } from "app/(app)/(published)/p/[didOrHandle]/[rkey]/p
 export default async function Post(props: {
   params: Promise<{ didOrHandle: string; rkey: string; quote: string }>;
 }) {
+  let params = await props.params;
   // Garbage quote params would each mint a permanent ISR entry.
-  if (!decodeQuotePosition(decodeURIComponent((await props.params).quote)))
-    notFound();
-  return <PostPage {...props} />;
+  let quotePosition = decodeQuotePosition(decodeURIComponent(params.quote));
+  if (!quotePosition) notFound();
+
+  let didOrHandle = decodeURIComponent(params.didOrHandle);
+  let did = await resolveDid(didOrHandle);
+  if (!did) notFound();
+  // Canonicalize handle URLs onto the DID form, matching the post page: the
+  // two spellings are separate cache entries and only the DID one is what
+  // publishing revalidates.
+  if (didOrHandle !== did)
+    redirect(
+      `/p/${encodeURIComponent(did)}/${params.rkey}/l-quote/${params.quote}`,
+    );
+
+  return (
+    <DocumentPageRenderer
+      did={did}
+      rkey={params.rkey}
+      openPageId={quotePosition.pageId}
+    />
+  );
 }

--- a/app/(app)/(published)/p/[didOrHandle]/[rkey]/opengraph-image.ts
+++ b/app/(app)/(published)/p/[didOrHandle]/[rkey]/opengraph-image.ts
@@ -1,7 +1,7 @@
 import { ogScreenshotResponse } from "src/utils/screenshotPage";
 import { supabaseServerClient } from "supabase/serverClient";
 import { jsonToLex } from "@atproto/lexicon";
-import { idResolver } from "src/identity";
+import { resolveDid } from "../resolveDid";
 import { fetchAtprotoBlob } from "app/api/atproto_images/route";
 import { normalizeDocumentRecord } from "src/utils/normalizeRecords";
 import { documentUriFilter } from "src/utils/uriHelpers";
@@ -15,23 +15,12 @@ export async function generateStaticParams() {
   return [];
 }
 
-
 export default async function OpenGraphImage(props: {
   params: Promise<{ rkey: string; didOrHandle: string }>;
 }) {
   let params = await props.params;
-  let didOrHandle = decodeURIComponent(params.didOrHandle);
-
-  // Resolve handle to DID if needed
-  let did = didOrHandle;
-  if (!didOrHandle.startsWith("did:")) {
-    try {
-      let resolved = await idResolver.handle.resolve(didOrHandle);
-      if (resolved) did = resolved;
-    } catch (e) {
-      // Fall back to screenshot if handle resolution fails
-    }
-  }
+  // Falls back to the screenshot when a handle doesn't resolve.
+  let did = await resolveDid(decodeURIComponent(params.didOrHandle));
 
   if (did) {
     // Try to get the document's cover image
@@ -49,8 +38,9 @@ export default async function OpenGraphImage(props: {
         try {
           // Get CID from the blob ref (handle both serialized and hydrated forms)
           let cid =
-            (docRecord.coverImage.ref as unknown as { $link: string })["$link"] ||
-            docRecord.coverImage.ref.toString();
+            (docRecord.coverImage.ref as unknown as { $link: string })[
+              "$link"
+            ] || docRecord.coverImage.ref.toString();
 
           let imageResponse = await fetchAtprotoBlob(did, cid);
           if (imageResponse) {

--- a/app/(app)/(published)/p/[didOrHandle]/[rkey]/page.tsx
+++ b/app/(app)/(published)/p/[didOrHandle]/[rkey]/page.tsx
@@ -1,13 +1,11 @@
 import { supabaseServerClient } from "supabase/serverClient";
 import { Metadata } from "next";
-import { cache } from "react";
-import { idResolver } from "src/identity";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import { resolveDid } from "../resolveDid";
 import { DocumentPageRenderer } from "app/(app)/(published)/lish/[did]/[publication]/[rkey]/DocumentPageRenderer";
 import { normalizeDocumentRecord } from "src/utils/normalizeRecords";
 import { documentUriFilter } from "src/utils/uriHelpers";
 import { getDocumentURL } from "src/utils/getPublicationURL";
-import { decodeQuotePosition } from "src/utils/quotePosition";
 
 // On-demand ISR: rendered on first request, then served from the CDN and
 // re-rendered in the background. The empty generateStaticParams is what opts a
@@ -20,29 +18,12 @@ export async function generateStaticParams() {
   return [];
 }
 
-// Memoized per request so the metadata and the page body resolve the handle
-// once. Failures stay failures — the memoized rejection re-throws, and each
-// caller treats an unresolvable handle as a 404.
-const resolveHandle = cache((handle: string) =>
-  idResolver.handle.resolve(handle),
-);
-
 export async function generateMetadata(props: {
   params: Promise<{ didOrHandle: string; rkey: string }>;
 }): Promise<Metadata> {
   let params = await props.params;
-  let didOrHandle = decodeURIComponent(params.didOrHandle);
-
-  // Resolve handle to DID if necessary
-  let did = didOrHandle;
-  if (!didOrHandle.startsWith("did:")) {
-    try {
-      let resolved = await resolveHandle(didOrHandle);
-      if (resolved) did = resolved;
-    } catch (e) {
-      return { title: "404" };
-    }
-  }
+  let did = await resolveDid(decodeURIComponent(params.didOrHandle));
+  if (!did) return { title: "404" };
 
   let { data: documents } = await supabaseServerClient
     .from("documents")
@@ -83,26 +64,17 @@ export async function generateMetadata(props: {
 }
 
 export default async function StandaloneDocumentPage(props: {
-  params: Promise<{ didOrHandle: string; rkey: string; quote?: string }>;
+  params: Promise<{ didOrHandle: string; rkey: string }>;
 }) {
   let params = await props.params;
   let didOrHandle = decodeURIComponent(params.didOrHandle);
+  let did = await resolveDid(didOrHandle);
+  if (!did) notFound();
+  // Canonicalize handle URLs onto the DID form so a document has one cache
+  // entry here instead of one per handle spelling — publishing revalidates
+  // the DID path, and a stale handle entry would outlive the update.
+  if (didOrHandle !== did)
+    redirect(`/p/${encodeURIComponent(did)}/${params.rkey}`);
 
-  // Resolve handle to DID if necessary
-  let did = didOrHandle;
-  if (!didOrHandle.startsWith("did:")) {
-    let resolved = await resolveHandle(didOrHandle).catch(() => null);
-    if (!resolved) notFound();
-    did = resolved;
-  }
-
-  return (
-    <DocumentPageRenderer
-      did={did}
-      rkey={params.rkey}
-      openPageId={
-        params.quote ? decodeQuotePosition(params.quote)?.pageId : undefined
-      }
-    />
-  );
+  return <DocumentPageRenderer did={did} rkey={params.rkey} />;
 }

--- a/app/(app)/(published)/p/[didOrHandle]/resolveDid.ts
+++ b/app/(app)/(published)/p/[didOrHandle]/resolveDid.ts
@@ -1,0 +1,16 @@
+import { cache } from "react";
+import { idResolver } from "src/identity";
+
+// The first path segment may be a DID or a handle. Memoized per request so the
+// metadata and the page body resolve it once; failures resolve to null and
+// each caller treats an unresolvable handle as a 404.
+export const resolveDid = cache(async function resolveDid(
+  didOrHandle: string,
+): Promise<string | null> {
+  if (didOrHandle.startsWith("did:")) return didOrHandle;
+  try {
+    return (await idResolver.handle.resolve(didOrHandle)) ?? null;
+  } catch {
+    return null;
+  }
+});

--- a/src/utils/revalidatePublication.ts
+++ b/src/utils/revalidatePublication.ts
@@ -30,22 +30,45 @@ export function revalidatePublicationPaths(
 }
 
 // A single post's pages: its base URL, the archive listing, its rkey path,
-// and its record `path` (if set to something other than the rkey) since
-// documents can publish under a custom path.
-export function revalidatePostPaths(
+// its record `path` (if set to something other than the rkey) since documents
+// can publish under a custom path, and the publication's own published pages,
+// any of which may carry a posts list that includes this post.
+function revalidatePostPaths(
   pubUri: string,
   name: string | null | undefined,
   rkey: string,
   docPath: string | null | undefined,
+  pagePaths: string[] = [],
 ) {
   revalidatePublicationPaths(pubUri, name, [
     "",
     "/archive",
     `/${rkey}`,
+    ...pagePaths,
     ...(docPath && docPath !== `/${rkey}`
       ? [docPath.startsWith("/") ? docPath : `/${docPath}`]
       : []),
   ]);
+}
+
+// Route-serving paths of each publication's published pages, keyed by
+// publication uri. External link tabs store a full URL in `path`; only real
+// routes count, and "/" is the publication base every caller already drops.
+async function publishedPagePathsByPublication(pubUris: string[]) {
+  const byPub = new Map<string, string[]>();
+  if (!pubUris.length) return byPub;
+  const { data } = await supabaseServerClient
+    .from("publication_pages")
+    .select("publication, path")
+    .in("publication", pubUris);
+  for (const row of data ?? []) {
+    if (!row.path || !row.path.startsWith("/") || row.path === "/") continue;
+    byPub.set(row.publication, [
+      ...(byPub.get(row.publication) ?? []),
+      row.path,
+    ]);
+  }
+  return byPub;
 }
 
 // Every cached page that lists or renders a document: the standalone /p/ URL
@@ -96,8 +119,19 @@ export async function revalidateDocumentPaths(
         docPath ?? (row.documents?.data as { path?: string } | null)?.path;
     }
   }
+  const pagePaths = await publishedPagePathsByPublication(
+    pubs.map((p) => p.uri),
+  );
   for (const pub of pubs)
-    revalidatePostPaths(pub.uri, pub.name, docUri.rkey, docPath);
+    revalidatePostPaths(
+      pub.uri,
+      pub.name,
+      docUri.rkey,
+      docPath,
+      pagePaths.get(pub.uri),
+    );
+  // Handle-form /p/ URLs canonical-redirect onto this one, so the did
+  // spelling is the only cache entry a document has here.
   revalidatePath(`/p/${docUri.host}/${docUri.rkey}`);
 }
 


### PR DESCRIPTION
Publishing from /publish revalidated the post's own page and its
publication's home/archive, which left three things serving pre-publish
title and description:

- Publication pages (`publication_pages`) can carry a posts list, and none
  of their paths were dropped, so a pub whose homepage or section page
  lists posts kept the old list — and the old titles — until the ISR timer
  expired.
- `/p/[didOrHandle]` accepts a handle as well as a DID and caches each
  spelling separately, but only the DID path was ever revalidated. Both
  post and quote routes now canonical-redirect handle URLs onto the DID
  form, the way `subscribe/[did]/[rkey]` already does, so a document has
  one entry there.
- publishToPublication invalidated only the publication it was handed;
  it now goes through revalidateDocumentPaths, the same helper the
  firehose endpoint and deletePost use, which enumerates every
  publication the document belongs to.

The publish form also sent the server-rendered title and description
rather than the draft's live ones. The publish page is dynamic but the
router cache holds its payload for staleTimes.dynamic, so arriving there
after an edit published the title the author had already changed — the
editor's Update button reads these from Replicache for exactly this
reason, and the form now does too.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BeYLC9356obHZyhHbXtWEh