### PR TITLE
Move screenshots back to the one-shot REST endpoint, edge-cache share cards

### DIFF
--- a/app/api/quote_screenshot/route.ts
+++ b/app/api/quote_screenshot/route.ts
@@ -21,6 +21,14 @@ export async function GET(req: NextRequest) {
   let image = await screenshotBskyCardImage(parsed.toString());
   if (!image) return new Response("Screenshot failed", { status: 502 });
   return new Response(new Uint8Array(image), {
-    headers: { "Content-Type": "image/webp" },
+    headers: {
+      "Content-Type": "image/webp",
+      // Edge-cache per url so repeat share-modal opens (and anything else
+      // hitting this route) don't each pay a multi-second browser render.
+      // An hour bounds how stale the card can be when resharing a
+      // just-edited post; the prefetch-while-composing flow hides the
+      // render latency of a cache miss.
+      "Cache-Control": "public, max-age=0, s-maxage=3600",
+    },
   });
 }

--- a/next.config.js
+++ b/next.config.js
@@ -31,7 +31,7 @@ const nextConfig = {
   // Caps the CDN stale-while-revalidate window for ISR pages (default is one
   // year — a bad cached page could be served stale that long).
   expireTime: 86400,
-  serverExternalPackages: ["yjs", "pino", "puppeteer-core"],
+  serverExternalPackages: ["yjs", "pino"],
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
   images: {
     loader: "custom",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "prosemirror-model": "^1.21.0",
         "prosemirror-schema-basic": "^1.2.2",
         "prosemirror-state": "^1.4.3",
-        "puppeteer-core": "^25.3.0",
         "react": "19.2.1",
         "react-aria-components": "^1.8.0",
         "react-day-picker": "^9.3.0",
@@ -4617,147 +4616,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@puppeteer/browsers": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
-      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "modern-tar": "^0.7.6",
-        "yargs": "^18.0.0"
-      },
-      "bin": {
-        "browsers": "lib/main-cli.js"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "proxy-agent": ">=8.0.1",
-        "yauzl": "^2.10.0 || ^3.4.0"
-      },
-      "peerDependenciesMeta": {
-        "proxy-agent": {
-          "optional": true
-        },
-        "yauzl": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -11320,22 +11178,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chromium-bidi": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
-      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mitt": "^3.0.1",
-        "zod": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
-      }
-    },
     "node_modules/citty": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
@@ -11939,12 +11781,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1638949",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz",
-      "integrity": "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/difflib": {
       "version": "0.2.4",
@@ -14000,6 +13836,21 @@
         }
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -14541,6 +14392,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/entities": {
@@ -16295,12 +16161,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
-    },
     "node_modules/mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
@@ -16314,15 +16174,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/modern-tar": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/module-details-from-path": {
@@ -17823,23 +17674,6 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer-core": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.3.0.tgz",
-      "integrity": "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "3.0.6",
-        "chromium-bidi": "16.0.1",
-        "devtools-protocol": "0.0.1638949",
-        "typed-query-selector": "^2.12.2",
-        "webdriver-bidi-protocol": "0.4.2",
-        "ws": "^8.21.0"
-      },
-      "engines": {
-        "node": ">=22.12.0"
       }
     },
     "node_modules/qs": {
@@ -20753,12 +20587,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typed-query-selector": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
-      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -21885,12 +21713,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
-      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "prosemirror-model": "^1.21.0",
     "prosemirror-schema-basic": "^1.2.2",
     "prosemirror-state": "^1.4.3",
-    "puppeteer-core": "^25.3.0",
     "react": "19.2.1",
     "react-aria-components": "^1.8.0",
     "react-day-picker": "^9.3.0",

--- a/src/utils/screenshotPage.ts
+++ b/src/utils/screenshotPage.ts
@@ -1,4 +1,3 @@
-import puppeteer, { type Browser, type Page } from "puppeteer-core";
 import { MAIN_SITE_URL } from "src/utils/customDomain";
 
 // Resolve an app path to an absolute url on this deployment's canonical origin.
@@ -39,42 +38,60 @@ export const serverRenderedPageWaits = {
   waitForTimeout: 500,
 } satisfies Partial<PageScreenshotOptions>;
 
-// Reuse one remote browser per server instance: launching is the slow part
-// (~2.5s); a warm session takes a screenshot in ~1-2s. Cloudflare closes the
-// session after it sits idle for keep_alive ms, and we reconnect lazily.
-let cachedBrowser: Promise<Browser> | null = null;
-
-function connectBrowser(): Promise<Browser> {
-  if (!cachedBrowser) {
-    cachedBrowser = puppeteer
-      .connect({
-        browserWSEndpoint: `wss://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT}/browser-rendering/devtools/browser?keep_alive=60000`,
-        headers: {
-          Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
-        },
-      })
-      .then((browser) => {
-        browser.once("disconnected", () => {
-          cachedBrowser = null;
-        });
-        return browser;
-      });
-    cachedBrowser.catch(() => {
-      cachedBrowser = null;
-    });
-  }
-  return cachedBrowser;
-}
-
-// Screenshot `url` at the given viewport over a warm CDP session against
-// Cloudflare's browser rendering service. Returns a png buffer, or null when
-// the screenshot fails, so callers can degrade instead of erroring.
+// Screenshot `url` at the given viewport via Cloudflare browser rendering's
+// one-shot REST endpoint. Cloudflare bills browser rendering by session
+// duration, and a REST session ends when the render does, so billed browser
+// time stays proportional to screenshots actually taken. Returns an image
+// buffer, or null when the screenshot fails, so callers can degrade instead
+// of erroring.
 export async function screenshotPage(
   url: string,
   options: PageScreenshotOptions,
 ): Promise<Buffer | null> {
   try {
-    return await cdpScreenshot(url, options);
+    let response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT}/browser-rendering/screenshot`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+        },
+        body: JSON.stringify({
+          url,
+          setJavaScriptEnabled: options.setJavaScriptEnabled,
+          screenshotOptions: options.screenshotOptions,
+          // Disabled page javascript also disables lazy-loading, so everything
+          // renders without a scroll pass — and skipping it keeps quote pages
+          // resting at their fragment anchor for the capture.
+          scrollPage:
+            options.scrollPage && options.setJavaScriptEnabled !== false,
+          // Overlay scrollbars would show in the capture.
+          addStyleTag: [{ content: `* {scrollbar-width:none; }` }],
+          gotoOptions: {
+            waitUntil: options.waitUntil,
+            // Bound navigation (default is 30s, max 60s) so a stalled
+            // subresource fails fast instead of hanging the whole render.
+            timeout: 30_000,
+          },
+          waitForTimeout: options.waitForTimeout,
+          viewport: {
+            width: options.width,
+            height: options.height,
+            deviceScaleFactor: options.deviceScaleFactor,
+          },
+        }),
+      },
+    );
+    if (!response.ok) {
+      console.error(
+        "Screenshot failed:",
+        response.status,
+        await response.text().catch(() => ""),
+      );
+      return null;
+    }
+    return Buffer.from(await response.arrayBuffer());
   } catch (e) {
     console.error("Screenshot failed:", e);
     return null;
@@ -82,8 +99,7 @@ export async function screenshotPage(
 }
 
 // Screenshot an app path and wrap it as an opengraph-image Response, at the
-// standard og viewport unless overridden. Screenshotting uses puppeteer, so
-// routes calling this must stay on the nodejs runtime.
+// standard og viewport unless overridden.
 export async function ogScreenshotResponse(
   path: string,
   options?: Partial<PageScreenshotOptions>,
@@ -105,76 +121,4 @@ export async function ogScreenshotResponse(
         "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
     },
   });
-}
-
-async function cdpScreenshot(
-  url: string,
-  options: PageScreenshotOptions,
-): Promise<Buffer> {
-  const browser = await connectBrowser();
-  const page = await browser.newPage();
-  try {
-    await page.setViewport({
-      width: options.width,
-      height: options.height,
-      deviceScaleFactor: options.deviceScaleFactor ?? 1,
-    });
-    if (options.setJavaScriptEnabled === false)
-      await page.setJavaScriptEnabled(false);
-    // Overlay scrollbars would show in the capture; hide them at the protocol
-    // level since injecting a style tag needs page javascript.
-    const session = await page.createCDPSession();
-    await session
-      .send("Emulation.setScrollbarsHidden", { hidden: true })
-      .catch(() => {});
-
-    await page.goto(url, { waitUntil: options.waitUntil, timeout: 30_000 });
-
-    // Disabled page javascript also disables lazy-loading, so everything is
-    // already loading and the scroll pass would be a no-op.
-    if (options.scrollPage && options.setJavaScriptEnabled !== false)
-      await scrollThroughPage(page);
-
-    // Navigation top-anchors the fragment target; re-scroll it to the center
-    // so the card shows document context on both sides of the quote.
-    // (Runtime.evaluate works even with page javascript disabled.)
-    const fragment = decodeURIComponent(new URL(url).hash.slice(1));
-    if (fragment) {
-      await page
-        .evaluate((id) => {
-          document.getElementById(id)?.scrollIntoView({ block: "center" });
-        }, fragment)
-        .catch(() => {});
-    }
-
-    if (options.waitForTimeout)
-      await new Promise((r) => setTimeout(r, options.waitForTimeout));
-
-    return Buffer.from(
-      await page.screenshot({
-        type: options.screenshotOptions?.type ?? "png",
-        quality: options.screenshotOptions?.quality,
-      }),
-    );
-  } finally {
-    // Close the page but keep the browser connected for the next capture.
-    await page.close().catch(() => {});
-  }
-}
-
-// Step through the full scroll height to trigger lazy-loaded content, then
-// return to the top (the resting position for whole-page captures; quote
-// captures re-scroll to their fragment afterwards).
-async function scrollThroughPage(page: Page) {
-  await page
-    .evaluate(async () => {
-      const scroller = document.scrollingElement;
-      if (!scroller) return;
-      for (let y = 0; y < scroller.scrollHeight; y += window.innerHeight) {
-        scroller.scrollTop = y;
-        await new Promise((r) => setTimeout(r, 50));
-      }
-      scroller.scrollTop = 0;
-    })
-    .catch(() => {});
 }


### PR DESCRIPTION
Cloudflare bills browser rendering by session duration, and the warm CDP
sessions behind screenshotPage held a browser open for a 60s keep-alive
tail after every capture — per server instance — so billed browser-hours
ran ~10x the actual render time (continuously, under steady unfurl
traffic). This drove the cost spike that started July 16.

Render through the REST /screenshot endpoint instead: each call's
session ends with the render, so billed time stays proportional to
screenshots taken. The day-long CDN caching on og-images and the
share modal's prefetch-while-composing already absorb the latency cost
of cold renders (~7s vs ~3.2s warm). Quote captures rest at their native
top-anchored fragment position rather than being re-centered via CDP.

Also give /api/quote_screenshot the per-url edge caching it was always
meant to have, so repeat share-modal opens for the same url stop each
paying a fresh browser render; an hour bounds card staleness when
resharing a just-edited post.

puppeteer-core is unused without the CDP connection; drop it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RRc1j5KHUokShmD17hRuZG