### PR TITLE
Add drag-and-drop reordering for list items

### DIFF
--- a/app/(app)/(identity)/lish/[did]/[publication]/edit/PublicationDraftEditor.tsx
+++ b/app/(app)/(identity)/lish/[did]/[publication]/edit/PublicationDraftEditor.tsx
@@ -64,14 +64,16 @@ export function PublicationDraftEditor(props: {
                   entityID={props.leaflet_id}
                   className="h-full flex items-stretch place-items-center"
                 >
-                  <PublicationDraftEditorContent
-                    leaflet_id={props.leaflet_id}
-                    did={props.did}
-                    record={record}
-                    iconUrl={iconUrl}
-                    publicationUri={props.publicationUri}
-                    newsletterMode={props.newsletterMode}
-                  />
+                  <ListDndProvider>
+                    <PublicationDraftEditorContent
+                      leaflet_id={props.leaflet_id}
+                      did={props.did}
+                      record={record}
+                      iconUrl={iconUrl}
+                      publicationUri={props.publicationUri}
+                      newsletterMode={props.newsletterMode}
+                    />
+                  </ListDndProvider>
                 </DraftLeafletBackground>
               </div>
               <PublicationEditMobileFooter />
@@ -160,46 +162,44 @@ function PublicationDraftEditorContent(props: {
         showPageBackground ? "mx-auto py-6" : "pt-2"
       }`}
     >
-      <ListDndProvider>
-        <Page
-          key={currentPage}
-          entityID={currentPage}
-          fullPageScroll={!showPageBackground}
-          header={
-            <>
-              <NewPublicationHeader
-                edit
-                hideSubscribeInHeader={hideSubscribeInHeader}
-                iconUrl={props.iconUrl}
-                wordmark={wordmark}
-                description={record?.description}
-                subscribe={{
-                  publicationUri: props.publicationUri,
-                  publicationUrl: record.url,
-                  publicationName: record.name,
-                  publicationDescription: record.description,
-                  newsletterMode: props.newsletterMode,
-                }}
-              />
+      <Page
+        key={currentPage}
+        entityID={currentPage}
+        fullPageScroll={!showPageBackground}
+        header={
+          <>
+            <NewPublicationHeader
+              edit
+              hideSubscribeInHeader={hideSubscribeInHeader}
+              iconUrl={props.iconUrl}
+              wordmark={wordmark}
+              description={record?.description}
+              subscribe={{
+                publicationUri: props.publicationUri,
+                publicationUrl: record.url,
+                publicationName: record.name,
+                publicationDescription: record.description,
+                newsletterMode: props.newsletterMode,
+              }}
+            />
 
-              <PublicationPagesEditNav
-                publicationUrl={record.url}
-                hideSubscribeInHeader={hideSubscribeInHeader}
-                subscribe={{
-                  publicationUri: props.publicationUri,
-                  publicationUrl: record.url,
-                  publicationName: record.name,
-                  publicationDescription: record.description,
-                  newsletterMode: props.newsletterMode,
-                }}
-                selectedPage={currentPage}
-                onSelectPage={setSelectedPage}
-              />
-              <div className="spacer h-3" />
-            </>
-          }
-        />
-      </ListDndProvider>
+            <PublicationPagesEditNav
+              publicationUrl={record.url}
+              hideSubscribeInHeader={hideSubscribeInHeader}
+              subscribe={{
+                publicationUri: props.publicationUri,
+                publicationUrl: record.url,
+                publicationName: record.name,
+                publicationDescription: record.description,
+                newsletterMode: props.newsletterMode,
+              }}
+              selectedPage={currentPage}
+              onSelectPage={setSelectedPage}
+            />
+            <div className="spacer h-3" />
+          </>
+        }
+      />
     </div>
   );
 }

--- a/app/(app)/(identity)/lish/[did]/[publication]/edit/PublicationDraftEditor.tsx
+++ b/app/(app)/(identity)/lish/[did]/[publication]/edit/PublicationDraftEditor.tsx
@@ -11,6 +11,7 @@ import { SelectionManager } from "components/SelectionManager";
 import { EntitySetProvider } from "components/EntitySetProvider";
 import { type NormalizedPublication } from "src/utils/normalizeRecords";
 import { Page } from "components/Pages/Page";
+import { ListDndProvider } from "components/Blocks/ListDnd";
 import { blobRefToSrc } from "src/utils/blobRefToSrc";
 import { NewPublicationHeader } from "app/(app)/(published)/lish/[did]/[publication]/PublicationHeader";
 import { PublicationPagesEditNav } from "./PublicationPagesEditNav";
@@ -159,44 +160,46 @@ function PublicationDraftEditorContent(props: {
         showPageBackground ? "mx-auto py-6" : "pt-2"
       }`}
     >
-      <Page
-        key={currentPage}
-        entityID={currentPage}
-        fullPageScroll={!showPageBackground}
-        header={
-          <>
-            <NewPublicationHeader
-              edit
-              hideSubscribeInHeader={hideSubscribeInHeader}
-              iconUrl={props.iconUrl}
-              wordmark={wordmark}
-              description={record?.description}
-              subscribe={{
-                publicationUri: props.publicationUri,
-                publicationUrl: record.url,
-                publicationName: record.name,
-                publicationDescription: record.description,
-                newsletterMode: props.newsletterMode,
-              }}
-            />
+      <ListDndProvider>
+        <Page
+          key={currentPage}
+          entityID={currentPage}
+          fullPageScroll={!showPageBackground}
+          header={
+            <>
+              <NewPublicationHeader
+                edit
+                hideSubscribeInHeader={hideSubscribeInHeader}
+                iconUrl={props.iconUrl}
+                wordmark={wordmark}
+                description={record?.description}
+                subscribe={{
+                  publicationUri: props.publicationUri,
+                  publicationUrl: record.url,
+                  publicationName: record.name,
+                  publicationDescription: record.description,
+                  newsletterMode: props.newsletterMode,
+                }}
+              />
 
-            <PublicationPagesEditNav
-              publicationUrl={record.url}
-              hideSubscribeInHeader={hideSubscribeInHeader}
-              subscribe={{
-                publicationUri: props.publicationUri,
-                publicationUrl: record.url,
-                publicationName: record.name,
-                publicationDescription: record.description,
-                newsletterMode: props.newsletterMode,
-              }}
-              selectedPage={currentPage}
-              onSelectPage={setSelectedPage}
-            />
-            <div className="spacer h-3" />
-          </>
-        }
-      />
+              <PublicationPagesEditNav
+                publicationUrl={record.url}
+                hideSubscribeInHeader={hideSubscribeInHeader}
+                subscribe={{
+                  publicationUri: props.publicationUri,
+                  publicationUrl: record.url,
+                  publicationName: record.name,
+                  publicationDescription: record.description,
+                  newsletterMode: props.newsletterMode,
+                }}
+                selectedPage={currentPage}
+                onSelectPage={setSelectedPage}
+              />
+              <div className="spacer h-3" />
+            </>
+          }
+        />
+      </ListDndProvider>
     </div>
   );
 }

--- a/components/Blocks/Block.tsx
+++ b/components/Blocks/Block.tsx
@@ -187,6 +187,13 @@ export const Block = memo(function Block(
     },
   );
 
+  let baseBlock = (
+    <BaseBlock
+      {...props}
+      areYouSure={areYouSure}
+      setAreYouSure={setAreYouSure}
+    />
+  );
   return (
     <div
       {...(!props.preview
@@ -247,17 +254,13 @@ export const Block = memo(function Block(
     >
       {!props.preview && <BlockMultiselectIndicator {...props} />}
       {dropIndicator && <ListDropIndicator indicator={dropIndicator} />}
-      <BlockListDnd
-        entityID={props.entityID}
-        isListItem={!!props.listData}
-        preview={props.preview}
-      >
-        <BaseBlock
-          {...props}
-          areYouSure={areYouSure}
-          setAreYouSure={setAreYouSure}
-        />
-      </BlockListDnd>
+      {props.preview || !entity_set.permissions.write ? (
+        baseBlock
+      ) : (
+        <BlockListDnd entityID={props.entityID} isListItem={!!props.listData}>
+          {baseBlock}
+        </BlockListDnd>
+      )}
     </div>
   );
 }, deepEqualsBlockProps);
@@ -268,24 +271,17 @@ export const Block = memo(function Block(
 // every `over` change during a drag: everything they touch here is memoized,
 // so the block subtree (passed through as `children`) bails out and only this
 // wiring re-renders. The measured node is an inset overlay div rather than the
-// block wrapper itself for the same reason. The preview copy rendered in the
-// DragOverlay must not register itself, hence the disabled/namespaced ids.
+// block wrapper itself for the same reason.
 const BlockListDnd = (props: {
   entityID: string;
   isListItem: boolean;
-  preview?: boolean;
   children: React.ReactNode;
 }) => {
-  let entity_set = useEntitySetContext();
-  let write = entity_set.permissions.write;
   let draggable = useDraggable({
-    id: props.preview ? `preview/${props.entityID}` : props.entityID,
-    disabled: !!props.preview || !props.isListItem || !write,
+    id: props.entityID,
+    disabled: !props.isListItem,
   });
-  let droppable = useDroppable({
-    id: props.preview ? `preview/${props.entityID}` : props.entityID,
-    disabled: !!props.preview || !write,
-  });
+  let droppable = useDroppable({ id: props.entityID });
   let setNodeRef = useCallback(
     (el: HTMLElement | null) => {
       draggable.setNodeRef(el);
@@ -293,33 +289,19 @@ const BlockListDnd = (props: {
     },
     [draggable.setNodeRef, droppable.setNodeRef],
   );
+  let { attributes, listeners, setActivatorNodeRef } = draggable;
   let dragHandle = useMemo(
     () =>
-      !props.preview && props.isListItem && write
-        ? {
-            attributes: draggable.attributes,
-            listeners: draggable.listeners,
-            setActivatorNodeRef: draggable.setActivatorNodeRef,
-          }
-        : null,
-    [
-      props.preview,
-      props.isListItem,
-      write,
-      draggable.attributes,
-      draggable.listeners,
-      draggable.setActivatorNodeRef,
-    ],
+      props.isListItem ? { attributes, listeners, setActivatorNodeRef } : null,
+    [props.isListItem, attributes, listeners, setActivatorNodeRef],
   );
   return (
     <>
-      {!props.preview && write && (
-        <div
-          ref={setNodeRef}
-          className="absolute inset-0 pointer-events-none"
-          aria-hidden
-        />
-      )}
+      <div
+        ref={setNodeRef}
+        className="absolute inset-0 pointer-events-none"
+        aria-hidden
+      />
       <ListDragHandleContext.Provider value={dragHandle}>
         {props.children}
       </ListDragHandleContext.Provider>
@@ -750,8 +732,8 @@ export const ListMarker = (
     >
       <button
         ref={dragHandle?.setActivatorNodeRef}
-        {...(dragHandle?.attributes ?? {})}
-        {...(dragHandle?.listeners ?? {})}
+        {...dragHandle?.attributes}
+        {...dragHandle?.listeners}
         onPointerDown={(e) => {
           dragHandle?.listeners?.onPointerDown?.(e);
           // Keep the hold from also triggering the block wrapper's own

--- a/components/Blocks/Block.tsx
+++ b/components/Blocks/Block.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { Fact, useEntity, useReplicache } from "src/replicache";
-import { memo, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
+import {
+  ListDragHandleContext,
+  didListDragJustEnd,
+  useListDragHandle,
+  useListDragState,
+} from "./ListDndState";
 import { useIsBlockSelected, useUIState } from "src/useUIState";
 import { useBlockMouseHandlers } from "./useBlockMouseHandlers";
 import { useBlockKeyboardHandlers } from "./useBlockKeyboardHandlers";
@@ -103,6 +110,23 @@ export const Block = memo(function Block(
     }
   });
 
+  // The dragged block and its whole subtree stay in place, dimmed, while the
+  // DragOverlay carries the preview.
+  let isDragSource = useListDragState(
+    (s) =>
+      !props.preview &&
+      s.activeId !== null &&
+      (s.activeId === props.entityID ||
+        !!props.listData?.path.some((p) => p.entity === s.activeId)),
+  );
+  // Encoded as a primitive so the zustand subscription only re-renders this
+  // block when its own indicator appears, moves edge, or changes depth.
+  let dropIndicator = useListDragState((s) =>
+    !props.preview && s.dropTarget?.entityID === props.entityID
+      ? `${s.dropTarget.edge}:${s.dropTarget.depth}`
+      : null,
+  );
+
   let selected = useIsBlockSelected(props.entityID);
   let focused = useUIState(
     (s) =>
@@ -185,6 +209,7 @@ export const Block = memo(function Block(
         px-3 sm:px-4 pt-1
 
         z-1 w-full
+        ${isDragSource ? "opacity-30" : ""}
         ${props.listData && focused ? "touch-pan-y" : ""}
       ${alignmentStyle}
       ${
@@ -219,14 +244,102 @@ export const Block = memo(function Block(
       }`}
     >
       {!props.preview && <BlockMultiselectIndicator {...props} />}
-      <BaseBlock
-        {...props}
-        areYouSure={areYouSure}
-        setAreYouSure={setAreYouSure}
-      />
+      {dropIndicator && <ListDropIndicator indicator={dropIndicator} />}
+      <BlockListDnd
+        entityID={props.entityID}
+        isListItem={!!props.listData}
+        preview={props.preview}
+      >
+        <BaseBlock
+          {...props}
+          areYouSure={areYouSure}
+          setAreYouSure={setAreYouSure}
+        />
+      </BlockListDnd>
     </div>
   );
 }, deepEqualsBlockProps);
+
+// Registers the block as a draggable list item and a drop target, and hands
+// the activator down to the ListMarker through ListDragHandleContext. Lives in
+// its own leaf component because dnd-kit's hooks re-render their consumers on
+// every `over` change during a drag: everything they touch here is memoized,
+// so the block subtree (passed through as `children`) bails out and only this
+// wiring re-renders. The measured node is an inset overlay div rather than the
+// block wrapper itself for the same reason. The preview copy rendered in the
+// DragOverlay must not register itself, hence the disabled/namespaced ids.
+const BlockListDnd = (props: {
+  entityID: string;
+  isListItem: boolean;
+  preview?: boolean;
+  children: React.ReactNode;
+}) => {
+  let entity_set = useEntitySetContext();
+  let write = entity_set.permissions.write;
+  let draggable = useDraggable({
+    id: props.preview ? `preview/${props.entityID}` : props.entityID,
+    disabled: !!props.preview || !props.isListItem || !write,
+  });
+  let droppable = useDroppable({
+    id: props.preview ? `preview/${props.entityID}` : props.entityID,
+    disabled: !!props.preview || !write,
+  });
+  let setNodeRef = useCallback(
+    (el: HTMLElement | null) => {
+      draggable.setNodeRef(el);
+      droppable.setNodeRef(el);
+    },
+    [draggable.setNodeRef, droppable.setNodeRef],
+  );
+  let dragHandle = useMemo(
+    () =>
+      !props.preview && props.isListItem && write
+        ? {
+            attributes: draggable.attributes,
+            listeners: draggable.listeners,
+            setActivatorNodeRef: draggable.setActivatorNodeRef,
+          }
+        : null,
+    [
+      props.preview,
+      props.isListItem,
+      write,
+      draggable.attributes,
+      draggable.listeners,
+      draggable.setActivatorNodeRef,
+    ],
+  );
+  return (
+    <>
+      {!props.preview && write && (
+        <div
+          ref={setNodeRef}
+          className="absolute inset-0 pointer-events-none"
+          aria-hidden
+        />
+      )}
+      <ListDragHandleContext.Provider value={dragHandle}>
+        {props.children}
+      </ListDragHandleContext.Provider>
+    </>
+  );
+};
+
+// The line marking where a dragged list item will drop, drawn on the edge of
+// the adjacent block and indented to the depth the item will land at.
+const ListDropIndicator = (props: { indicator: string }) => {
+  let [edge, depth] = props.indicator.split(":");
+  return (
+    <div
+      className={`listDropIndicator pointer-events-none absolute left-3 right-3 sm:left-4 sm:right-4 z-10 h-[3px] rounded-full bg-accent-contrast ${
+        edge === "top" ? "-top-[2px]" : "-bottom-[2px]"
+      }`}
+      style={{
+        marginLeft: `calc(${parseInt(depth, 10) - 1} * var(--list-marker-width))`,
+      }}
+    />
+  );
+};
 
 // Everything the Block render tree reads off its props. headingLevel /
 // headingPath / listData.checked / listData.listStart are deliberately not
@@ -575,6 +688,7 @@ export const ListMarker = (
   let depth = props.listData?.depth;
   let { permissions } = useEntitySetContext();
   let { rep } = useReplicache();
+  let dragHandle = useListDragHandle();
 
   let [editingNumber, setEditingNumber] = useState(false);
   let [numberInputValue, setNumberInputValue] = useState("");
@@ -633,10 +747,20 @@ export const ListMarker = (
       }}
     >
       <button
+        ref={dragHandle?.setActivatorNodeRef}
+        {...(dragHandle?.attributes ?? {})}
+        {...(dragHandle?.listeners ?? {})}
+        onPointerDown={(e) => {
+          dragHandle?.listeners?.onPointerDown?.(e);
+          // Keep the hold from also triggering the block wrapper's own
+          // long-press/swipe handlers while the drag sensor's delay runs.
+          if (dragHandle) e.stopPropagation();
+        }}
         onClick={() => {
+          if (didListDragJustEnd()) return;
           if (children.length > 0) toggleFold(rep, props.entityID);
         }}
-        className={`listMarker group/list-marker ${listStyle?.data.value === "ordered" ? "" : "px-3 py-2"} ${children.length > 0 ? "cursor-pointer" : "cursor-default"}`}
+        className={`listMarker group/list-marker ${listStyle?.data.value === "ordered" ? "" : "px-3 py-2"} ${children.length > 0 ? "cursor-pointer" : "cursor-default"} ${dragHandle ? "touch-none select-none" : ""}`}
       >
         {listStyle?.data.value === "ordered" ? (
           editingNumber ? (

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -45,10 +45,19 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
 
   let sensors = useSensors(
     useSensor(PointerSensor, {
-      // Long press. The OS long-press timeout isn't exposed to the web;
-      // 250ms matches native drag-lift timing (and dnd-kit's recommended
-      // touch delay) while a quick tap still falls through as a click.
-      activationConstraint: { delay: 250, tolerance: 5 },
+      // The drag starts on whichever comes first: a 250ms hold (the OS
+      // long-press timeout isn't exposed to the web; 250ms matches native
+      // drag-lift timing and dnd-kit's recommended touch delay) or 8px of
+      // pointer travel. A quick clean tap still falls through as a click.
+      // dnd-kit reuses the one tolerance field as a movement-cancel in both
+      // constraint branches, and checks it before the distance start — the
+      // sentinel keeps any finite movement resolving as a drag start, never
+      // a cancel.
+      activationConstraint: {
+        delay: 250,
+        distance: 8,
+        tolerance: Number.MAX_SAFE_INTEGER,
+      },
     }),
   );
 

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -55,6 +55,8 @@ export function ListDndContext(props: {
   let pointerRef = useRef<{ x: number; y: number } | null>(null);
   let rectsRef = useRef<Map<UniqueIdentifier, ClientRect> | null>(null);
   let dropRef = useRef<ListDropTarget | null>(null);
+  // One horizontal indent unit, read from the theme at drag start.
+  let indentWidthRef = useRef(38);
   let blocksRef = useRef(props.blocks);
   blocksRef.current = props.blocks;
   let foldedRef = useRef(foldedBlocks);
@@ -72,6 +74,12 @@ export function ListDndContext(props: {
     let index = arr.findIndex((b) => b.entityID === dragActive.id);
     let block = arr[index];
     if (!block?.listData) return;
+    indentWidthRef.current =
+      parseInt(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--list-marker-width",
+        ),
+      ) || 38;
     // Build the same props the page's block map would pass, so the drag
     // preview renders the identical component.
     let nextBlock = arr[index + 1] || null;
@@ -88,13 +96,15 @@ export function ListDndContext(props: {
     useListDragState.setState({ activeId: block.entityID, dropTarget: null });
   };
 
-  let onDragMove = ({ active: dragActive, over }: DragMoveEvent) => {
+  let onDragMove = ({ active: dragActive, over, delta }: DragMoveEvent) => {
     let target =
       over && pointerRef.current
         ? computeDropTarget(
             String(dragActive.id),
             String(over.id),
             pointerRef.current.y,
+            delta.x,
+            indentWidthRef.current,
             rectsRef.current?.get(over.id),
             blocksRef.current,
             props.pageID,
@@ -120,7 +130,7 @@ export function ListDndContext(props: {
     let activeBlock = active;
     reset();
     if (!rep || !target || !activeBlock?.listData) return;
-    if (target.unfoldHeading) unfoldBlocks(rep, [target.unfoldHeading]);
+    if (target.unfold) unfoldBlocks(rep, [target.unfold]);
     rep.mutate.moveBlock({
       block: activeBlock.entityID,
       oldParent: activeBlock.listData.parent,
@@ -154,6 +164,8 @@ function computeDropTarget(
   activeId: string,
   overId: string,
   pointerY: number,
+  deltaX: number,
+  indentWidth: number,
   overRect: ClientRect | undefined,
   blocks: Block[],
   pageID: string,
@@ -161,7 +173,8 @@ function computeDropTarget(
 ): ListDropTarget | null {
   if (!overRect) return null;
   let overIndex = blocks.findIndex((b) => b.entityID === overId);
-  if (overIndex === -1) return null;
+  let activeBlock = blocks.find((b) => b.entityID === activeId);
+  if (overIndex === -1 || !activeBlock?.listData) return null;
   let edge: "top" | "bottom" =
     pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
   let above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
@@ -174,28 +187,59 @@ function computeDropTarget(
   // Gaps touching the dragged subtree are either no-ops or drops into itself.
   if (inActiveSubtree(above) || inActiveSubtree(below)) return null;
 
-  // The dropped item fits the depth context of the gap: it takes the depth of
-  // the item below the line, or continues the list above when nothing follows.
-  if (below?.listData)
+  // Horizontal drag distance projects the preferred depth (one indent unit
+  // per level), clamped to what the gap allows: no shallower than the item
+  // below the line, no deeper than one level under the item above it.
+  let minDepth = below?.listData?.depth ?? 1;
+  let maxDepth = above?.listData ? above.listData.depth + 1 : 1;
+  let depth = Math.min(
+    maxDepth,
+    Math.max(
+      minDepth,
+      activeBlock.listData.depth + Math.round(deltaX / indentWidth),
+    ),
+  );
+
+  if (below?.listData && depth === below.listData.depth)
     return {
       entityID: overId,
       edge,
-      depth: below.listData.depth,
+      depth,
       newParent: below.listData.parent,
       position: { type: "before", entity: below.entityID },
     };
-  if (above)
+  if (above) {
+    // Deeper than the item below: land inside the list context of the block
+    // above. Its ancestor at `depth` is the sibling to follow; when there is
+    // none (depth is one level under `above`) the item becomes its first
+    // child.
+    let newParent =
+      depth === 1
+        ? pageID
+        : above.listData?.path.find((p) => p.depth === depth - 1)?.entity;
+    if (!newParent) return null;
+    let anchor = above.listData
+      ? above.listData.path.find((p) => p.depth === depth)?.entity
+      : above.entityID;
+    // Landing as the first child of a collapsed `above`, or directly after a
+    // folded heading (inside its hidden section), would put the block into
+    // hidden content. Landing as a *sibling* after a folded list item is fine.
+    let landsInHiddenContent =
+      !anchor || (anchor === above.entityID && !above.listData);
     return {
       entityID: overId,
       edge,
-      depth: above.listData?.depth ?? 1,
-      newParent: above.listData?.parent ?? pageID,
-      position: { type: "after", entity: above.entityID },
-      unfoldHeading:
-        above.type === "heading" && foldedBlocks.includes(above.entityID)
+      depth,
+      newParent,
+      position: anchor
+        ? { type: "after", entity: anchor }
+        : { type: "first" },
+      unfold:
+        landsInHiddenContent && foldedBlocks.includes(above.entityID)
           ? above.entityID
           : undefined,
     };
+  }
   return {
     entityID: overId,
     edge,
@@ -216,6 +260,6 @@ function dropTargetEquals(a: ListDropTarget | null, b: ListDropTarget | null) {
     a.position.type === b.position.type &&
     ("entity" in a.position ? a.position.entity : null) ===
       ("entity" in b.position ? b.position.entity : null) &&
-    a.unfoldHeading === b.unfoldHeading
+    a.unfold === b.unfold
   );
 }

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import {
+  ClientRect,
+  CollisionDetection,
+  DndContext,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  UniqueIdentifier,
+  closestCenter,
+  pointerWithin,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { useReplicache } from "src/replicache";
+import { useFoldedBlocks } from "components/FoldStateProvider";
+import { unfoldBlocks } from "src/utils/foldBlocks";
+import {
+  ListDropTarget,
+  markListDragEnd,
+  useListDragState,
+} from "./ListDndState";
+import { Block, BlockProps } from "./Block";
+
+// Drag and drop reordering for list items. Each Block registers itself as a
+// draggable (activated from its ListMarker by long press) and a droppable;
+// this context computes where the drop would land, publishes it through
+// useListDragState for the indicator line, and applies it as a single
+// moveBlock mutation on drop.
+export function ListDndContext(props: {
+  pageID: string;
+  // Visible blocks in document order — the same array the page maps over.
+  blocks: Block[];
+  children: React.ReactNode;
+}) {
+  let { rep } = useReplicache();
+  let foldedBlocks = useFoldedBlocks();
+
+  let sensors = useSensors(
+    useSensor(PointerSensor, {
+      // Long press, matching the app's 500ms useLongPress convention.
+      activationConstraint: { delay: 500, tolerance: 5 },
+    }),
+  );
+
+  let [active, setActive] = useState<BlockProps | null>(null);
+
+  // The drop computation must agree with the collision pass on coordinates,
+  // so the collision function stashes the pointer and droppable rects it was
+  // given and onDragMove reads them back.
+  let pointerRef = useRef<{ x: number; y: number } | null>(null);
+  let rectsRef = useRef<Map<UniqueIdentifier, ClientRect> | null>(null);
+  let dropRef = useRef<ListDropTarget | null>(null);
+  let blocksRef = useRef(props.blocks);
+  blocksRef.current = props.blocks;
+  let foldedRef = useRef(foldedBlocks);
+  foldedRef.current = foldedBlocks;
+
+  let collisionDetection = useCallback<CollisionDetection>((args) => {
+    pointerRef.current = args.pointerCoordinates;
+    rectsRef.current = args.droppableRects;
+    let within = pointerWithin(args);
+    return within.length > 0 ? within : closestCenter(args);
+  }, []);
+
+  let onDragStart = ({ active: dragActive }: DragStartEvent) => {
+    let arr = blocksRef.current;
+    let index = arr.findIndex((b) => b.entityID === dragActive.id);
+    let block = arr[index];
+    if (!block?.listData) return;
+    // Build the same props the page's block map would pass, so the drag
+    // preview renders the identical component.
+    let nextBlock = arr[index + 1] || null;
+    let nextDepth = nextBlock?.listData?.depth || 1;
+    setActive({
+      ...block,
+      pageType: "doc",
+      parent: props.pageID,
+      previousBlock: arr[index - 1] || null,
+      nextBlock,
+      nextPosition:
+        block.listData.depth === nextDepth ? nextBlock?.position || null : null,
+    });
+    useListDragState.setState({ activeId: block.entityID, dropTarget: null });
+  };
+
+  let onDragMove = ({ active: dragActive, over }: DragMoveEvent) => {
+    let target =
+      over && pointerRef.current
+        ? computeDropTarget(
+            String(dragActive.id),
+            String(over.id),
+            pointerRef.current.y,
+            rectsRef.current?.get(over.id),
+            blocksRef.current,
+            props.pageID,
+            foldedRef.current,
+          )
+        : null;
+    dropRef.current = target;
+    // Only publish when the target actually changes, so pointer movement
+    // within the same gap doesn't re-render anything.
+    if (!dropTargetEquals(useListDragState.getState().dropTarget, target))
+      useListDragState.setState({ dropTarget: target });
+  };
+
+  let reset = () => {
+    dropRef.current = null;
+    setActive(null);
+    markListDragEnd();
+    useListDragState.setState({ activeId: null, dropTarget: null });
+  };
+
+  let onDragEnd = (_e: DragEndEvent) => {
+    let target = dropRef.current;
+    let activeBlock = active;
+    reset();
+    if (!rep || !target || !activeBlock?.listData) return;
+    if (target.unfoldHeading) unfoldBlocks(rep, [target.unfoldHeading]);
+    rep.mutate.moveBlock({
+      block: activeBlock.entityID,
+      oldParent: activeBlock.listData.parent,
+      newParent: target.newParent,
+      position: target.position,
+    });
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={collisionDetection}
+      onDragStart={onDragStart}
+      onDragMove={onDragMove}
+      onDragEnd={onDragEnd}
+      onDragCancel={reset}
+    >
+      {props.children}
+      <DragOverlay dropAnimation={null}>
+        {active && (
+          <div className="listDragPreview scale-[1.02] drop-shadow-md">
+            <Block {...active} preview />
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+function computeDropTarget(
+  activeId: string,
+  overId: string,
+  pointerY: number,
+  overRect: ClientRect | undefined,
+  blocks: Block[],
+  pageID: string,
+  foldedBlocks: readonly string[],
+): ListDropTarget | null {
+  if (!overRect) return null;
+  let overIndex = blocks.findIndex((b) => b.entityID === overId);
+  if (overIndex === -1) return null;
+  let edge: "top" | "bottom" =
+    pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
+  let above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
+  let below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
+
+  let inActiveSubtree = (b: Block | undefined) =>
+    !!b &&
+    (b.entityID === activeId ||
+      !!b.listData?.path.some((p) => p.entity === activeId));
+  // Gaps touching the dragged subtree are either no-ops or drops into itself.
+  if (inActiveSubtree(above) || inActiveSubtree(below)) return null;
+
+  // The dropped item fits the depth context of the gap: it takes the depth of
+  // the item below the line, or continues the list above when nothing follows.
+  if (below?.listData)
+    return {
+      entityID: overId,
+      edge,
+      depth: below.listData.depth,
+      newParent: below.listData.parent,
+      position: { type: "before", entity: below.entityID },
+    };
+  if (above)
+    return {
+      entityID: overId,
+      edge,
+      depth: above.listData?.depth ?? 1,
+      newParent: above.listData?.parent ?? pageID,
+      position: { type: "after", entity: above.entityID },
+      unfoldHeading:
+        above.type === "heading" && foldedBlocks.includes(above.entityID)
+          ? above.entityID
+          : undefined,
+    };
+  return {
+    entityID: overId,
+    edge,
+    depth: 1,
+    newParent: pageID,
+    position: { type: "first" },
+  };
+}
+
+function dropTargetEquals(a: ListDropTarget | null, b: ListDropTarget | null) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.entityID === b.entityID &&
+    a.edge === b.edge &&
+    a.depth === b.depth &&
+    a.newParent === b.newParent &&
+    a.position.type === b.position.type &&
+    ("entity" in a.position ? a.position.entity : null) ===
+      ("entity" in b.position ? b.position.entity : null) &&
+    a.unfoldHeading === b.unfoldHeading
+  );
+}

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -16,9 +16,11 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
+import { getEventCoordinates } from "@dnd-kit/utilities";
 import { Replicache } from "replicache";
 import { ReplicacheMutators, useReplicache } from "src/replicache";
 import { scanIndex } from "src/replicache/utils";
+import { elementId } from "src/utils/elementId";
 import { useFoldedBlocks } from "components/FoldStateProvider";
 import { unfoldBlocks } from "src/utils/foldBlocks";
 import {
@@ -60,6 +62,13 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
   let dropRef = useRef<ListDropTarget | null>(null);
   // One horizontal indent unit, read from the theme at drag start.
   let indentWidthRef = useRef(38);
+  // Where on its own row the drag started (pointer x minus the row's left
+  // edge). Depth projection measures horizontal travel against the hovered
+  // row's left edge relative to this, which equals plain pointer delta within
+  // one page but stays meaningful across side-by-side pages — raw delta would
+  // absorb the whole page-to-page distance and pin cross-page drops to the
+  // clamp.
+  let startRelXRef = useRef(0);
   // The dragged block and the page it came from, set synchronously at drag
   // start so the move handlers never race the re-render.
   let activeRef = useRef<Block | null>(null);
@@ -78,13 +87,22 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
     return within.length > 0 ? within : closestCenter(args);
   }, []);
 
-  let onDragStart = ({ active: dragActive }: DragStartEvent) => {
+  let onDragStart = ({
+    active: dragActive,
+    activatorEvent,
+  }: DragStartEvent) => {
     let page = findListDndPageForBlock(String(dragActive.id));
     if (!page) return;
     let arr = page.blocks;
     let index = arr.findIndex((b) => b.entityID === dragActive.id);
     let block = arr[index];
     if (!block?.listData) return;
+    let rowLeft =
+      document
+        .getElementById(elementId.block(block.entityID).container)
+        ?.getBoundingClientRect().left ?? 0;
+    startRelXRef.current =
+      (getEventCoordinates(activatorEvent)?.x ?? rowLeft) - rowLeft;
     indentWidthRef.current =
       parseInt(
         getComputedStyle(document.documentElement).getPropertyValue(
@@ -116,7 +134,7 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
     useListDragState.setState({ activeId: block.entityID, dropTarget: null });
   };
 
-  let onDragMove = ({ over, delta }: DragMoveEvent) => {
+  let onDragMove = ({ over }: DragMoveEvent) => {
     let activeBlock = activeRef.current;
     let page = over ? findListDndPageForBlock(String(over.id)) : undefined;
     let crossPage = !!page && page.pageID !== activePageRef.current;
@@ -133,8 +151,8 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
         ? computeDropTarget(
             activeBlock,
             String(over.id),
-            pointerRef.current.y,
-            delta.x,
+            pointerRef.current,
+            startRelXRef.current,
             indentWidthRef.current,
             rectsRef.current?.get(over.id),
             page,
@@ -239,8 +257,8 @@ async function getDescendantPages(
 function computeDropTarget(
   activeBlock: Block,
   overId: string,
-  pointerY: number,
-  deltaX: number,
+  pointer: { x: number; y: number },
+  startRelX: number,
   indentWidth: number,
   overRect: ClientRect | undefined,
   // The page the pointer is over — not necessarily the page the dragged
@@ -289,7 +307,7 @@ function computeDropTarget(
       above = slotAbove;
       below = slotBelow;
     } else {
-      edge = pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
+      edge = pointer.y < overRect.top + overRect.height / 2 ? "top" : "bottom";
       above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
       below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
       if (inActiveSubtree(above)) above = slotAbove;
@@ -299,7 +317,7 @@ function computeDropTarget(
       (above?.entityID ?? null) === (slotAbove?.entityID ?? null) &&
       (below?.entityID ?? null) === (slotBelow?.entityID ?? null);
   } else {
-    edge = pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
+    edge = pointer.y < overRect.top + overRect.height / 2 ? "top" : "bottom";
     above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
     below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
   }
@@ -307,9 +325,14 @@ function computeDropTarget(
     ? { entityID: activeId, edge: "top" as const }
     : { entityID: overId, edge };
 
-  // Horizontal drag distance projects the preferred depth (one indent unit
-  // per level), clamped to what the gap allows: from one level above the item
+  // Horizontal travel projects the preferred depth (one indent unit per
+  // level), clamped to what the gap allows: from one level above the item
   // below the line (a list split) down to one level under the item above it.
+  // Travel is measured against the hovered row's left edge relative to where
+  // on its own row the drag started, so it carries across side-by-side pages.
+  // The baseline (the item's own depth) is clamped into range first, so a
+  // deep item over a shallow gap adjusts from the gap's range instead of
+  // needing to claw back the clamped-away distance.
   let minDepth = below?.listData
     ? Math.max(floor, below.listData.depth - 1)
     : floor;
@@ -318,12 +341,14 @@ function computeDropTarget(
     : above
       ? 1
       : minDepth;
+  let offsetX = pointer.x - overRect.left - startRelX;
+  let neutralDepth = Math.min(
+    maxDepth,
+    Math.max(minDepth, activeBlock.listData.depth),
+  );
   let depth = Math.min(
     maxDepth,
-    Math.max(
-      minDepth,
-      activeBlock.listData.depth + Math.round(deltaX / indentWidth),
-    ),
+    Math.max(minDepth, neutralDepth + Math.round(offsetX / indentWidth)),
   );
   // Back in its own slot at its own depth: not a move.
   if (ownSlot && depth === activeBlock.listData.depth) return null;

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -133,12 +133,23 @@ export function ListDndContext(props: {
     reset();
     if (!rep || !target || !activeBlock?.listData) return;
     if (target.unfold) unfoldBlocks(rep, [target.unfold]);
-    rep.mutate.moveBlock({
-      block: activeBlock.entityID,
-      oldParent: activeBlock.listData.parent,
-      newParent: target.newParent,
-      position: target.position,
-    });
+    if (target.adopt && target.position.type === "after") {
+      rep.mutate.moveBlockAdoptingSiblings({
+        block: activeBlock.entityID,
+        oldParent: activeBlock.listData.parent,
+        newParent: target.newParent,
+        after: target.position.entity,
+        adoptParent: target.adopt.parent,
+        adoptFrom: target.adopt.from,
+      });
+    } else {
+      rep.mutate.moveBlock({
+        block: activeBlock.entityID,
+        oldParent: activeBlock.listData.parent,
+        newParent: target.newParent,
+        position: target.position,
+      });
+    }
   };
 
   return (
@@ -175,24 +186,52 @@ function computeDropTarget(
 ): ListDropTarget | null {
   if (!overRect) return null;
   let overIndex = blocks.findIndex((b) => b.entityID === overId);
-  let activeBlock = blocks.find((b) => b.entityID === activeId);
+  let activeIndex = blocks.findIndex((b) => b.entityID === activeId);
+  let activeBlock = blocks[activeIndex];
   if (overIndex === -1 || !activeBlock?.listData) return null;
-  let edge: "top" | "bottom" =
-    pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
-  let above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
-  let below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
 
   let inActiveSubtree = (b: Block | undefined) =>
     !!b &&
     (b.entityID === activeId ||
       !!b.listData?.path.some((p) => p.entity === activeId));
-  // Gaps touching the dragged subtree are either no-ops or drops into itself.
-  if (inActiveSubtree(above) || inActiveSubtree(below)) return null;
+
+  // Treat the document as if the dragged subtree were lifted out: the gaps on
+  // either side of it collapse into its own slot, whose neighbors are the
+  // blocks just outside the subtree. That makes the item's starting position
+  // a valid target, so a purely horizontal drag projects an indent/outdent.
+  let subtreeEnd = activeIndex;
+  while (
+    subtreeEnd + 1 < blocks.length &&
+    inActiveSubtree(blocks[subtreeEnd + 1])
+  )
+    subtreeEnd++;
+  let slotAbove = blocks[activeIndex - 1];
+  let slotBelow = blocks[subtreeEnd + 1];
+
+  let above: Block | undefined;
+  let below: Block | undefined;
+  let edge: "top" | "bottom" = "top";
+  if (inActiveSubtree(blocks[overIndex])) {
+    above = slotAbove;
+    below = slotBelow;
+  } else {
+    edge = pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
+    above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
+    below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
+    if (inActiveSubtree(above)) above = slotAbove;
+    if (inActiveSubtree(below)) below = slotBelow;
+  }
+  let ownSlot =
+    (above?.entityID ?? null) === (slotAbove?.entityID ?? null) &&
+    (below?.entityID ?? null) === (slotBelow?.entityID ?? null);
+  let indicator = ownSlot
+    ? { entityID: activeId, edge: "top" as const }
+    : { entityID: overId, edge };
 
   // Horizontal drag distance projects the preferred depth (one indent unit
-  // per level), clamped to what the gap allows: no shallower than the item
-  // below the line, no deeper than one level under the item above it.
-  let minDepth = below?.listData?.depth ?? 1;
+  // per level), clamped to what the gap allows: from one level above the item
+  // below the line (a list split) down to one level under the item above it.
+  let minDepth = below?.listData ? Math.max(1, below.listData.depth - 1) : 1;
   let maxDepth = above?.listData ? above.listData.depth + 1 : 1;
   let depth = Math.min(
     maxDepth,
@@ -201,15 +240,36 @@ function computeDropTarget(
       activeBlock.listData.depth + Math.round(deltaX / indentWidth),
     ),
   );
+  // Back in its own slot at its own depth: not a move.
+  if (ownSlot && depth === activeBlock.listData.depth) return null;
 
   if (below?.listData && depth === below.listData.depth)
     return {
-      entityID: overId,
-      edge,
+      ...indicator,
       depth,
       newParent: below.listData.parent,
       position: { type: "before", entity: below.entityID },
     };
+  if (below?.listData && depth === below.listData.depth - 1) {
+    // One level above the run below the line: the dropped item splits the
+    // list, landing after the run's parent and adopting the run as children,
+    // which keeps the run's rendered depth. At the item's own slot this is
+    // exactly a swipe-outdent.
+    let splitParent = below.listData.parent;
+    let newParent =
+      depth === 1
+        ? pageID
+        : below.listData.path.find((p) => p.depth === depth - 1)?.entity;
+    if (!newParent) return null;
+    return {
+      ...indicator,
+      depth,
+      newParent,
+      position: { type: "after", entity: splitParent },
+      adopt: { parent: splitParent, from: below.entityID },
+      unfold: foldedBlocks.includes(activeId) ? activeId : undefined,
+    };
+  }
   if (above) {
     // Deeper than the item below: land inside the list context of the block
     // above. Its ancestor at `depth` is the sibling to follow; when there is
@@ -229,8 +289,7 @@ function computeDropTarget(
     let landsInHiddenContent =
       !anchor || (anchor === above.entityID && !above.listData);
     return {
-      entityID: overId,
-      edge,
+      ...indicator,
       depth,
       newParent,
       position: anchor
@@ -243,8 +302,7 @@ function computeDropTarget(
     };
   }
   return {
-    entityID: overId,
-    edge,
+    ...indicator,
     depth: 1,
     newParent: pageID,
     position: { type: "first" },
@@ -262,6 +320,8 @@ function dropTargetEquals(a: ListDropTarget | null, b: ListDropTarget | null) {
     a.position.type === b.position.type &&
     ("entity" in a.position ? a.position.entity : null) ===
       ("entity" in b.position ? b.position.entity : null) &&
+    (a.adopt?.parent ?? null) === (b.adopt?.parent ?? null) &&
+    (a.adopt?.from ?? null) === (b.adopt?.from ?? null) &&
     a.unfold === b.unfold
   );
 }

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -42,8 +42,10 @@ export function ListDndContext(props: {
 
   let sensors = useSensors(
     useSensor(PointerSensor, {
-      // Long press, matching the app's 500ms useLongPress convention.
-      activationConstraint: { delay: 500, tolerance: 5 },
+      // Long press. The OS long-press timeout isn't exposed to the web;
+      // 250ms matches native drag-lift timing (and dnd-kit's recommended
+      // touch delay) while a quick tap still falls through as a click.
+      activationConstraint: { delay: 250, tolerance: 5 },
     }),
   );
 

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -5,12 +5,10 @@ import {
   ClientRect,
   CollisionDetection,
   DndContext,
-  DragEndEvent,
   DragMoveEvent,
   DragOverlay,
   DragStartEvent,
   PointerSensor,
-  UniqueIdentifier,
   closestCenter,
   pointerWithin,
   useSensor,
@@ -37,10 +35,9 @@ import { Block, BlockProps } from "./Block";
 // and each page's Blocks registers its visible block list (see ListDndState).
 // This provider mounts once above all open pages, so an item can be dropped
 // into any of them: it computes where the drop would land, publishes it
-// through useListDragState for the indicator line, and applies it as a single
-// mutation on drop.
+// through useListDragState for the indicator line, and applies it on drop.
 export function ListDndProvider(props: { children: React.ReactNode }) {
-  let { rep } = useReplicache();
+  let { rep, undoManager } = useReplicache();
   let foldedBlocks = useFoldedBlocks();
 
   let sensors = useSensors(
@@ -63,35 +60,19 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
 
   let [active, setActive] = useState<BlockProps | null>(null);
 
+  // Everything about the drag in flight, set synchronously at drag start so
+  // the move handlers never race the re-render.
+  let dragRef = useRef<ListDrag | null>(null);
   // The drop computation must agree with the collision pass on coordinates,
-  // so the collision function stashes the pointer and droppable rects it was
-  // given and onDragMove reads them back.
+  // so the collision function stashes the pointer it was given and
+  // onDragMove reads it back.
   let pointerRef = useRef<{ x: number; y: number } | null>(null);
-  let rectsRef = useRef<Map<UniqueIdentifier, ClientRect> | null>(null);
   let dropRef = useRef<ListDropTarget | null>(null);
-  // One horizontal indent unit, read from the theme at drag start.
-  let indentWidthRef = useRef(38);
-  // Where on its own row the drag started (pointer x minus the row's left
-  // edge). Depth projection measures horizontal travel against the hovered
-  // row's left edge relative to this, which equals plain pointer delta within
-  // one page but stays meaningful across side-by-side pages — raw delta would
-  // absorb the whole page-to-page distance and pin cross-page drops to the
-  // clamp.
-  let startRelXRef = useRef(0);
-  // The dragged block and the page it came from, set synchronously at drag
-  // start so the move handlers never race the re-render.
-  let activeRef = useRef<Block | null>(null);
-  let activePageRef = useRef<string | null>(null);
-  // Pages living inside the dragged subtree (via its page-link blocks):
-  // dropping into one would make the block a descendant of itself. Resolved
-  // asynchronously at drag start; until then cross-page drops are withheld.
-  let forbiddenPagesRef = useRef<Set<string> | null>(null);
   let foldedRef = useRef(foldedBlocks);
   foldedRef.current = foldedBlocks;
 
   let collisionDetection = useCallback<CollisionDetection>((args) => {
     pointerRef.current = args.pointerCoordinates;
-    rectsRef.current = args.droppableRects;
     let within = pointerWithin(args);
     return within.length > 0 ? within : closestCenter(args);
   }, []);
@@ -110,20 +91,22 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
       document
         .getElementById(elementId.block(block.entityID).container)
         ?.getBoundingClientRect().left ?? 0;
-    startRelXRef.current =
-      (getEventCoordinates(activatorEvent)?.x ?? rowLeft) - rowLeft;
-    indentWidthRef.current =
-      parseInt(
-        getComputedStyle(document.documentElement).getPropertyValue(
-          "--list-marker-width",
-        ),
-      ) || 38;
-    activeRef.current = block;
-    activePageRef.current = page.pageID;
-    forbiddenPagesRef.current = null;
+    let drag: ListDrag = {
+      block,
+      pageID: page.pageID,
+      startRelX: (getEventCoordinates(activatorEvent)?.x ?? rowLeft) - rowLeft,
+      indentWidth:
+        parseInt(
+          getComputedStyle(document.documentElement).getPropertyValue(
+            "--list-marker-width",
+          ),
+        ) || 38,
+      forbiddenPages: null,
+    };
+    dragRef.current = drag;
     if (rep)
       getDescendantPages(rep, block.entityID).then((pages) => {
-        forbiddenPagesRef.current = pages;
+        drag.forbiddenPages = pages;
       });
     // Build the same props the page's block map would pass, so the drag
     // preview renders the identical component.
@@ -144,26 +127,23 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
   };
 
   let onDragMove = ({ over }: DragMoveEvent) => {
-    let activeBlock = activeRef.current;
+    let drag = dragRef.current;
     let page = over ? findListDndPageForBlock(String(over.id)) : undefined;
-    let crossPage = !!page && page.pageID !== activePageRef.current;
+    let crossPage = !!page && page.pageID !== drag?.pageID;
     let target =
       over &&
       pointerRef.current &&
-      activeBlock &&
+      drag &&
       page &&
       // Cross-page drops wait for the descendant-page walk, then exclude
       // pages living inside the dragged subtree.
       (!crossPage ||
-        (!!forbiddenPagesRef.current &&
-          !forbiddenPagesRef.current.has(page.pageID)))
+        (!!drag.forbiddenPages && !drag.forbiddenPages.has(page.pageID)))
         ? computeDropTarget(
-            activeBlock,
+            drag,
             String(over.id),
             pointerRef.current,
-            startRelXRef.current,
-            indentWidthRef.current,
-            rectsRef.current?.get(over.id),
+            over.rect,
             page,
             foldedRef.current,
           )
@@ -175,43 +155,49 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
     dropRef.current = target;
     // Only publish when the target actually changes, so pointer movement
     // within the same gap doesn't re-render anything.
-    if (!dropTargetEquals(useListDragState.getState().dropTarget, target))
+    let prev = useListDragState.getState().dropTarget;
+    if (JSON.stringify(prev) !== JSON.stringify(target))
       useListDragState.setState({ dropTarget: target });
   };
 
   let reset = () => {
     dropRef.current = null;
-    activeRef.current = null;
-    activePageRef.current = null;
-    forbiddenPagesRef.current = null;
+    dragRef.current = null;
     setActive(null);
     markListDragEnd();
     useListDragState.setState({ activeId: null, dropTarget: null });
   };
 
-  let onDragEnd = (_e: DragEndEvent) => {
+  let onDragEnd = () => {
     let target = dropRef.current;
-    let activeBlock = activeRef.current;
+    let block = dragRef.current?.block;
     reset();
-    if (!rep || !target || !activeBlock?.listData) return;
+    if (!rep || !target || !block?.listData) return;
     if (target.unfold) unfoldBlocks(rep, [target.unfold]);
-    if (target.adopt && target.position.type === "after") {
-      rep.mutate.moveBlockAdoptingSiblings({
-        block: activeBlock.entityID,
-        oldParent: activeBlock.listData.parent,
-        newParent: target.newParent,
-        after: target.position.entity,
-        adoptParent: target.adopt.parent,
-        adoptFrom: target.adopt.from,
-      });
-    } else {
-      rep.mutate.moveBlock({
-        block: activeBlock.entityID,
-        oldParent: activeBlock.listData.parent,
+    let adopt = target.adopt;
+    if (!adopt)
+      return rep.mutate.moveBlock({
+        block: block.entityID,
+        oldParent: block.listData.parent,
         newParent: target.newParent,
         position: target.position,
       });
-    }
+    // A list split is a move into the run followed by a plain outdent, which
+    // reparents the rest of the run under the block.
+    undoManager.withUndoGroup(async () => {
+      await rep.mutate.moveBlock({
+        block: block.entityID,
+        oldParent: block.listData!.parent,
+        newParent: adopt.parent,
+        position: { type: "before", entity: adopt.from },
+      });
+      await rep.mutate.outdentBlock({
+        block: block.entityID,
+        oldParent: adopt.parent,
+        newParent: target.newParent,
+        after: adopt.parent,
+      });
+    });
   };
 
   return (
@@ -234,6 +220,24 @@ export function ListDndProvider(props: { children: React.ReactNode }) {
     </DndContext>
   );
 }
+
+type ListDrag = {
+  block: Block;
+  pageID: string;
+  // Where on its own row the drag started (pointer x minus the row's left
+  // edge). Depth projection measures horizontal travel against the hovered
+  // row's left edge relative to this, which equals plain pointer delta within
+  // one page but stays meaningful across side-by-side pages — raw delta would
+  // absorb the whole page-to-page distance and pin cross-page drops to the
+  // clamp.
+  startRelX: number;
+  // One horizontal indent unit, read from the theme at drag start.
+  indentWidth: number;
+  // Pages living inside the dragged subtree (via its page-link blocks):
+  // dropping into one would make the block a descendant of itself. Resolved
+  // asynchronously at drag start; until then cross-page drops are withheld.
+  forbiddenPages: Set<string> | null;
+};
 
 // Every page reachable from inside `root`'s subtree through page-link (card)
 // blocks, transitively — the pages a drop must never target.
@@ -264,18 +268,17 @@ async function getDescendantPages(
 }
 
 function computeDropTarget(
-  activeBlock: Block,
+  drag: ListDrag,
   overId: string,
   pointer: { x: number; y: number },
-  startRelX: number,
-  indentWidth: number,
-  overRect: ClientRect | undefined,
+  overRect: ClientRect,
   // The page the pointer is over — not necessarily the page the dragged
   // block came from.
   page: ListDndPage,
   foldedBlocks: readonly string[],
 ): ListDropTarget | null {
-  if (!overRect || !activeBlock.listData) return null;
+  let activeBlock = drag.block;
+  if (!activeBlock.listData) return null;
   let { blocks, pageID } = page;
   // The shallowest depth this view may host: 1, or the zoom root's child
   // depth in a zoomed view (so nothing lands outside the zoomed subtree).
@@ -293,9 +296,10 @@ function computeDropTarget(
     (b.entityID === activeId ||
       !!b.listData?.path.some((p) => p.entity === activeId));
 
-  let above: Block | undefined;
-  let below: Block | undefined;
-  let edge: "top" | "bottom" = "top";
+  let edge: "top" | "bottom" =
+    pointer.y < overRect.top + overRect.height / 2 ? "top" : "bottom";
+  let above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
+  let below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
   let ownSlot = false;
   if (samePage) {
     // Treat the page as if the dragged subtree were lifted out: the gaps on
@@ -311,24 +315,11 @@ function computeDropTarget(
       subtreeEnd++;
     let slotAbove = blocks[activeIndex - 1];
     let slotBelow = blocks[subtreeEnd + 1];
-
-    if (inActiveSubtree(blocks[overIndex])) {
+    if (inActiveSubtree(blocks[overIndex]) || inActiveSubtree(above))
       above = slotAbove;
+    if (inActiveSubtree(blocks[overIndex]) || inActiveSubtree(below))
       below = slotBelow;
-    } else {
-      edge = pointer.y < overRect.top + overRect.height / 2 ? "top" : "bottom";
-      above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
-      below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
-      if (inActiveSubtree(above)) above = slotAbove;
-      if (inActiveSubtree(below)) below = slotBelow;
-    }
-    ownSlot =
-      (above?.entityID ?? null) === (slotAbove?.entityID ?? null) &&
-      (below?.entityID ?? null) === (slotBelow?.entityID ?? null);
-  } else {
-    edge = pointer.y < overRect.top + overRect.height / 2 ? "top" : "bottom";
-    above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
-    below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
+    ownSlot = above === slotAbove && below === slotBelow;
   }
   let indicator = ownSlot
     ? { entityID: activeId, edge: "top" as const }
@@ -350,14 +341,14 @@ function computeDropTarget(
     : above
       ? 1
       : minDepth;
-  let offsetX = pointer.x - overRect.left - startRelX;
+  let offsetX = pointer.x - overRect.left - drag.startRelX;
   let neutralDepth = Math.min(
     maxDepth,
     Math.max(minDepth, activeBlock.listData.depth),
   );
   let depth = Math.min(
     maxDepth,
-    Math.max(minDepth, neutralDepth + Math.round(offsetX / indentWidth)),
+    Math.max(minDepth, neutralDepth + Math.round(offsetX / drag.indentWidth)),
   );
   // Back in its own slot at its own depth: not a move.
   if (ownSlot && depth === activeBlock.listData.depth) return null;
@@ -428,21 +419,4 @@ function computeDropTarget(
     newParent: pageID,
     position: { type: "first" },
   };
-}
-
-function dropTargetEquals(a: ListDropTarget | null, b: ListDropTarget | null) {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  return (
-    a.entityID === b.entityID &&
-    a.edge === b.edge &&
-    a.depth === b.depth &&
-    a.newParent === b.newParent &&
-    a.position.type === b.position.type &&
-    ("entity" in a.position ? a.position.entity : null) ===
-      ("entity" in b.position ? b.position.entity : null) &&
-    (a.adopt?.parent ?? null) === (b.adopt?.parent ?? null) &&
-    (a.adopt?.from ?? null) === (b.adopt?.from ?? null) &&
-    a.unfold === b.unfold
-  );
 }

--- a/components/Blocks/ListDnd.tsx
+++ b/components/Blocks/ListDnd.tsx
@@ -16,32 +16,28 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { useReplicache } from "src/replicache";
+import { Replicache } from "replicache";
+import { ReplicacheMutators, useReplicache } from "src/replicache";
+import { scanIndex } from "src/replicache/utils";
 import { useFoldedBlocks } from "components/FoldStateProvider";
 import { unfoldBlocks } from "src/utils/foldBlocks";
 import {
+  ListDndPage,
   ListDropTarget,
+  findListDndPageForBlock,
   markListDragEnd,
   useListDragState,
 } from "./ListDndState";
 import { Block, BlockProps } from "./Block";
 
 // Drag and drop reordering for list items. Each Block registers itself as a
-// draggable (activated from its ListMarker by long press) and a droppable;
-// this context computes where the drop would land, publishes it through
-// useListDragState for the indicator line, and applies it as a single
-// moveBlock mutation on drop.
-export function ListDndContext(props: {
-  pageID: string;
-  // Visible blocks in document order — the same array the page maps over.
-  blocks: Block[];
-  // When the page is zoomed into a list item, the zoom root's absolute depth.
-  // Drops are floored to the root's child depth so nothing can be dragged out
-  // of the zoomed subtree, and indicator depths are converted to display
-  // depths.
-  zoomDepth?: number;
-  children: React.ReactNode;
-}) {
+// draggable (activated from its ListMarker by long press) and a droppable,
+// and each page's Blocks registers its visible block list (see ListDndState).
+// This provider mounts once above all open pages, so an item can be dropped
+// into any of them: it computes where the drop would land, publishes it
+// through useListDragState for the indicator line, and applies it as a single
+// mutation on drop.
+export function ListDndProvider(props: { children: React.ReactNode }) {
   let { rep } = useReplicache();
   let foldedBlocks = useFoldedBlocks();
 
@@ -64,8 +60,14 @@ export function ListDndContext(props: {
   let dropRef = useRef<ListDropTarget | null>(null);
   // One horizontal indent unit, read from the theme at drag start.
   let indentWidthRef = useRef(38);
-  let blocksRef = useRef(props.blocks);
-  blocksRef.current = props.blocks;
+  // The dragged block and the page it came from, set synchronously at drag
+  // start so the move handlers never race the re-render.
+  let activeRef = useRef<Block | null>(null);
+  let activePageRef = useRef<string | null>(null);
+  // Pages living inside the dragged subtree (via its page-link blocks):
+  // dropping into one would make the block a descendant of itself. Resolved
+  // asynchronously at drag start; until then cross-page drops are withheld.
+  let forbiddenPagesRef = useRef<Set<string> | null>(null);
   let foldedRef = useRef(foldedBlocks);
   foldedRef.current = foldedBlocks;
 
@@ -77,7 +79,9 @@ export function ListDndContext(props: {
   }, []);
 
   let onDragStart = ({ active: dragActive }: DragStartEvent) => {
-    let arr = blocksRef.current;
+    let page = findListDndPageForBlock(String(dragActive.id));
+    if (!page) return;
+    let arr = page.blocks;
     let index = arr.findIndex((b) => b.entityID === dragActive.id);
     let block = arr[index];
     if (!block?.listData) return;
@@ -87,6 +91,13 @@ export function ListDndContext(props: {
           "--list-marker-width",
         ),
       ) || 38;
+    activeRef.current = block;
+    activePageRef.current = page.pageID;
+    forbiddenPagesRef.current = null;
+    if (rep)
+      getDescendantPages(rep, block.entityID).then((pages) => {
+        forbiddenPagesRef.current = pages;
+      });
     // Build the same props the page's block map would pass, so the drag
     // preview renders the identical component.
     let nextBlock = arr[index + 1] || null;
@@ -98,35 +109,42 @@ export function ListDndContext(props: {
       nextBlock,
       nextPosition:
         block.listData.depth === nextDepth ? nextBlock?.position || null : null,
-      displayDepth: props.zoomDepth
-        ? block.listData.depth - props.zoomDepth + 1
+      displayDepth: page.zoomDepth
+        ? block.listData.depth - page.zoomDepth + 1
         : undefined,
     });
     useListDragState.setState({ activeId: block.entityID, dropTarget: null });
   };
 
-  let onDragMove = ({ active: dragActive, over, delta }: DragMoveEvent) => {
+  let onDragMove = ({ over, delta }: DragMoveEvent) => {
+    let activeBlock = activeRef.current;
+    let page = over ? findListDndPageForBlock(String(over.id)) : undefined;
+    let crossPage = !!page && page.pageID !== activePageRef.current;
     let target =
-      over && pointerRef.current
+      over &&
+      pointerRef.current &&
+      activeBlock &&
+      page &&
+      // Cross-page drops wait for the descendant-page walk, then exclude
+      // pages living inside the dragged subtree.
+      (!crossPage ||
+        (!!forbiddenPagesRef.current &&
+          !forbiddenPagesRef.current.has(page.pageID)))
         ? computeDropTarget(
-            String(dragActive.id),
+            activeBlock,
             String(over.id),
             pointerRef.current.y,
             delta.x,
             indentWidthRef.current,
             rectsRef.current?.get(over.id),
-            blocksRef.current,
-            props.pageID,
-            // In a zoomed view nothing may land shallower than the zoom
-            // root's children.
-            props.zoomDepth ? props.zoomDepth + 1 : 1,
+            page,
             foldedRef.current,
           )
         : null;
     // The placement fields stay absolute; the indicator's depth renders in
-    // display space (the zoom root displays at depth 1).
-    if (target && props.zoomDepth)
-      target = { ...target, depth: target.depth - props.zoomDepth + 1 };
+    // display space (a zoomed page displays its zoom root at depth 1).
+    if (target && page?.zoomDepth)
+      target = { ...target, depth: target.depth - page.zoomDepth + 1 };
     dropRef.current = target;
     // Only publish when the target actually changes, so pointer movement
     // within the same gap doesn't re-render anything.
@@ -136,6 +154,9 @@ export function ListDndContext(props: {
 
   let reset = () => {
     dropRef.current = null;
+    activeRef.current = null;
+    activePageRef.current = null;
+    forbiddenPagesRef.current = null;
     setActive(null);
     markListDragEnd();
     useListDragState.setState({ activeId: null, dropTarget: null });
@@ -143,7 +164,7 @@ export function ListDndContext(props: {
 
   let onDragEnd = (_e: DragEndEvent) => {
     let target = dropRef.current;
-    let activeBlock = active;
+    let activeBlock = activeRef.current;
     reset();
     if (!rep || !target || !activeBlock?.listData) return;
     if (target.unfold) unfoldBlocks(rep, [target.unfold]);
@@ -187,60 +208,101 @@ export function ListDndContext(props: {
   );
 }
 
+// Every page reachable from inside `root`'s subtree through page-link (card)
+// blocks, transitively — the pages a drop must never target.
+async function getDescendantPages(
+  rep: Replicache<ReplicacheMutators>,
+  root: string,
+): Promise<Set<string>> {
+  return rep.query(async (tx) => {
+    let scan = scanIndex(tx);
+    let pages = new Set<string>();
+    let queue = [root];
+    while (queue.length > 0) {
+      let entity = queue.pop()!;
+      let children = [
+        ...(await scan.eav(entity, "card/block")),
+        ...(await scan.eav(entity, "canvas/block")),
+      ];
+      for (let child of children) queue.push(child.data.value);
+      for (let card of await scan.eav(entity, "block/card")) {
+        if (!pages.has(card.data.value)) {
+          pages.add(card.data.value);
+          queue.push(card.data.value);
+        }
+      }
+    }
+    return pages;
+  });
+}
+
 function computeDropTarget(
-  activeId: string,
+  activeBlock: Block,
   overId: string,
   pointerY: number,
   deltaX: number,
   indentWidth: number,
   overRect: ClientRect | undefined,
-  blocks: Block[],
-  pageID: string,
-  // The shallowest depth this view may host (1, or the zoom root's child
-  // depth in a zoomed view).
-  floor: number,
+  // The page the pointer is over — not necessarily the page the dragged
+  // block came from.
+  page: ListDndPage,
   foldedBlocks: readonly string[],
 ): ListDropTarget | null {
-  if (!overRect) return null;
+  if (!overRect || !activeBlock.listData) return null;
+  let { blocks, pageID } = page;
+  // The shallowest depth this view may host: 1, or the zoom root's child
+  // depth in a zoomed view (so nothing lands outside the zoomed subtree).
+  let floor = page.zoomDepth ? page.zoomDepth + 1 : 1;
+  let activeId = activeBlock.entityID;
   let overIndex = blocks.findIndex((b) => b.entityID === overId);
+  if (overIndex === -1) return null;
+  // When dragging into a different page, the dragged subtree isn't in this
+  // page's block list at all, so there is no own slot and nothing to lift out.
   let activeIndex = blocks.findIndex((b) => b.entityID === activeId);
-  let activeBlock = blocks[activeIndex];
-  if (overIndex === -1 || !activeBlock?.listData) return null;
+  let samePage = activeIndex !== -1;
 
   let inActiveSubtree = (b: Block | undefined) =>
     !!b &&
     (b.entityID === activeId ||
       !!b.listData?.path.some((p) => p.entity === activeId));
 
-  // Treat the document as if the dragged subtree were lifted out: the gaps on
-  // either side of it collapse into its own slot, whose neighbors are the
-  // blocks just outside the subtree. That makes the item's starting position
-  // a valid target, so a purely horizontal drag projects an indent/outdent.
-  let subtreeEnd = activeIndex;
-  while (
-    subtreeEnd + 1 < blocks.length &&
-    inActiveSubtree(blocks[subtreeEnd + 1])
-  )
-    subtreeEnd++;
-  let slotAbove = blocks[activeIndex - 1];
-  let slotBelow = blocks[subtreeEnd + 1];
-
   let above: Block | undefined;
   let below: Block | undefined;
   let edge: "top" | "bottom" = "top";
-  if (inActiveSubtree(blocks[overIndex])) {
-    above = slotAbove;
-    below = slotBelow;
+  let ownSlot = false;
+  if (samePage) {
+    // Treat the page as if the dragged subtree were lifted out: the gaps on
+    // either side of it collapse into its own slot, whose neighbors are the
+    // blocks just outside the subtree. That makes the item's starting
+    // position a valid target, so a purely horizontal drag projects an
+    // indent/outdent.
+    let subtreeEnd = activeIndex;
+    while (
+      subtreeEnd + 1 < blocks.length &&
+      inActiveSubtree(blocks[subtreeEnd + 1])
+    )
+      subtreeEnd++;
+    let slotAbove = blocks[activeIndex - 1];
+    let slotBelow = blocks[subtreeEnd + 1];
+
+    if (inActiveSubtree(blocks[overIndex])) {
+      above = slotAbove;
+      below = slotBelow;
+    } else {
+      edge = pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
+      above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
+      below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
+      if (inActiveSubtree(above)) above = slotAbove;
+      if (inActiveSubtree(below)) below = slotBelow;
+    }
+    ownSlot =
+      (above?.entityID ?? null) === (slotAbove?.entityID ?? null) &&
+      (below?.entityID ?? null) === (slotBelow?.entityID ?? null);
   } else {
     edge = pointerY < overRect.top + overRect.height / 2 ? "top" : "bottom";
     above = edge === "top" ? blocks[overIndex - 1] : blocks[overIndex];
     below = edge === "top" ? blocks[overIndex] : blocks[overIndex + 1];
-    if (inActiveSubtree(above)) above = slotAbove;
-    if (inActiveSubtree(below)) below = slotBelow;
   }
-  let ownSlot =
-    (above?.entityID ?? null) === (slotAbove?.entityID ?? null) &&
-    (below?.entityID ?? null) === (slotBelow?.entityID ?? null);
   let indicator = ownSlot
     ? { entityID: activeId, edge: "top" as const }
     : { entityID: overId, edge };
@@ -315,9 +377,7 @@ function computeDropTarget(
       ...indicator,
       depth,
       newParent,
-      position: anchor
-        ? { type: "after", entity: anchor }
-        : { type: "first" },
+      position: anchor ? { type: "after", entity: anchor } : { type: "first" },
       unfold:
         landsInHiddenContent && foldedBlocks.includes(above.entityID)
           ? above.entityID

--- a/components/Blocks/ListDndState.ts
+++ b/components/Blocks/ListDndState.ts
@@ -1,0 +1,52 @@
+import { createContext, useContext } from "react";
+import type {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from "@dnd-kit/core";
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+// Where a dragged list item would land: enough to render the indicator line
+// (entityID + edge + depth) and to apply the move on drop (newParent + position).
+export type ListDropTarget = {
+  entityID: string;
+  edge: "top" | "bottom";
+  depth: number;
+  newParent: string;
+  position:
+    | { type: "first" }
+    | { type: "before"; entity: string }
+    | { type: "after"; entity: string };
+  // A folded heading the drop lands directly after; it must be unfolded on
+  // drop so the moved block doesn't disappear into its hidden section.
+  unfoldHeading?: string;
+};
+
+// Blocks subscribe with primitive-returning selectors so only the dragged
+// subtree and the block carrying the indicator re-render during a drag.
+export const useListDragState = create(
+  combine(
+    {
+      activeId: null as string | null,
+      dropTarget: null as ListDropTarget | null,
+    },
+    () => ({}),
+  ),
+);
+
+// Handed from Block (which owns the useDraggable registration, so the drag
+// rect is the whole block row) down to the ListMarker that acts as the handle.
+export const ListDragHandleContext = createContext<null | {
+  attributes: DraggableAttributes;
+  listeners: DraggableSyntheticListeners;
+  setActivatorNodeRef: (element: HTMLElement | null) => void;
+}>(null);
+export const useListDragHandle = () => useContext(ListDragHandleContext);
+
+// The browser fires a click on the handle after a drop; the marker's own
+// click action (fold toggle) needs a way to ignore it.
+let lastDragEndedAt = 0;
+export const markListDragEnd = () => {
+  lastDragEndedAt = Date.now();
+};
+export const didListDragJustEnd = () => Date.now() - lastDragEndedAt < 250;

--- a/components/Blocks/ListDndState.ts
+++ b/components/Blocks/ListDndState.ts
@@ -5,6 +5,30 @@ import type {
 } from "@dnd-kit/core";
 import { create } from "zustand";
 import { combine } from "zustand/middleware";
+import type { Block } from "components/Blocks/Block";
+
+// Every mounted page's visible block list, so the drag handlers (which live
+// in one ListDndProvider above all open pages) can resolve which page a
+// droppable belongs to and compute drops across pages. Written from each
+// Blocks render via effect; read only inside drag event handlers.
+export type ListDndPage = {
+  pageID: string;
+  blocks: Block[];
+  zoomDepth?: number;
+};
+const pageRegistry = new Map<string, ListDndPage>();
+export const registerListDndPage = (page: ListDndPage) => {
+  pageRegistry.set(page.pageID, page);
+};
+export const unregisterListDndPage = (pageID: string) => {
+  pageRegistry.delete(pageID);
+};
+export const findListDndPageForBlock = (
+  entityID: string,
+): ListDndPage | undefined => {
+  for (let page of pageRegistry.values())
+    if (page.blocks.some((b) => b.entityID === entityID)) return page;
+};
 
 // Where a dragged list item would land: enough to render the indicator line
 // (entityID + edge + depth) and to apply the move on drop (newParent + position).

--- a/components/Blocks/ListDndState.ts
+++ b/components/Blocks/ListDndState.ts
@@ -16,17 +16,11 @@ export type ListDndPage = {
   blocks: Block[];
   zoomDepth?: number;
 };
-const pageRegistry = new Map<string, ListDndPage>();
-export const registerListDndPage = (page: ListDndPage) => {
-  pageRegistry.set(page.pageID, page);
-};
-export const unregisterListDndPage = (pageID: string) => {
-  pageRegistry.delete(pageID);
-};
+export const listDndPages = new Map<string, ListDndPage>();
 export const findListDndPageForBlock = (
   entityID: string,
 ): ListDndPage | undefined => {
-  for (let page of pageRegistry.values())
+  for (let page of listDndPages.values())
     if (page.blocks.some((b) => b.entityID === entityID)) return page;
 };
 

--- a/components/Blocks/ListDndState.ts
+++ b/components/Blocks/ListDndState.ts
@@ -17,9 +17,14 @@ export type ListDropTarget = {
     | { type: "first" }
     | { type: "before"; entity: string }
     | { type: "after"; entity: string };
+  // Present when the drop lands one level above the list run below the line:
+  // the children of `parent` from `from` onward are adopted under the dropped
+  // block (a list split, keeping the run's rendered depth).
+  adopt?: { parent: string; from: string };
   // A folded block the drop lands directly inside or after (a collapsed new
-  // parent, or a folded heading's section); it must be unfolded on drop so
-  // the moved block doesn't disappear into its hidden content.
+  // parent, a folded heading's section, or the dragged block itself when it
+  // adopts a run); it must be unfolded on drop so nothing disappears into
+  // hidden content.
   unfold?: string;
 };
 

--- a/components/Blocks/ListDndState.ts
+++ b/components/Blocks/ListDndState.ts
@@ -17,9 +17,10 @@ export type ListDropTarget = {
     | { type: "first" }
     | { type: "before"; entity: string }
     | { type: "after"; entity: string };
-  // A folded heading the drop lands directly after; it must be unfolded on
-  // drop so the moved block doesn't disappear into its hidden section.
-  unfoldHeading?: string;
+  // A folded block the drop lands directly inside or after (a collapsed new
+  // parent, or a folded heading's section); it must be unfolded on drop so
+  // the moved block doesn't disappear into its hidden content.
+  unfold?: string;
 };
 
 // Blocks subscribe with primitive-returning selectors so only the dragged

--- a/components/Blocks/index.tsx
+++ b/components/Blocks/index.tsx
@@ -18,7 +18,7 @@ import { Block } from "./Block";
 import { useEffect, useMemo, useState } from "react";
 import { addShortcut } from "src/shortcuts";
 import { useHandleDrop } from "./useHandleDrop";
-import { ListDndContext } from "./ListDnd";
+import { registerListDndPage, unregisterListDndPage } from "./ListDndState";
 import { useFootnoteContext } from "components/Footnotes/FootnoteContext";
 
 export function Blocks(props: { entityID: string }) {
@@ -73,6 +73,17 @@ export function Blocks(props: { entityID: string }) {
 
   let lastVisibleBlock = visibleBlocks.at(-1);
 
+  // Make this page a drop target for list items dragged from any open page
+  // (the DndContext lives in ListDndProvider, above all pages).
+  useEffect(() => {
+    registerListDndPage({
+      pageID: props.entityID,
+      blocks: visibleBlocks,
+      zoomDepth,
+    });
+    return () => unregisterListDndPage(props.entityID);
+  }, [props.entityID, visibleBlocks, zoomDepth]);
+
   let { footnotes } = useFootnoteContext();
 
   let [areFootnotes, setAreFootnotes] = useState(false);
@@ -91,37 +102,31 @@ export function Blocks(props: { entityID: string }) {
       // collapse out through the container's top edge.
       className={`blocks w-full flow-root outline-hidden ${areFootnotes ? "h-fit" : "min-h-full"}`}
     >
-      <ListDndContext
-        pageID={props.entityID}
-        blocks={visibleBlocks}
-        zoomDepth={zoomDepth}
-      >
-        {visibleBlocks.map((f, index, arr) => {
-          let nextBlock = arr[index + 1];
-          let depth = f.listData?.depth || 1;
-          let nextDepth = nextBlock?.listData?.depth || 1;
-          let nextPosition: string | null;
-          if (depth === nextDepth) nextPosition = nextBlock?.position || null;
-          else nextPosition = null;
-          return (
-            <Block
-              pageType="doc"
-              {...f}
-              key={f.entityID}
-              entityID={f.entityID}
-              previousBlock={arr[index - 1] || null}
-              nextBlock={arr[index + 1] || null}
-              nextPosition={nextPosition}
-              headingFoldable={foldableParentSet.has(f.entityID) && !f.listData}
-              displayDepth={
-                zoomDepth && f.listData
-                  ? f.listData.depth - zoomDepth + 1
-                  : undefined
-              }
-            />
-          );
-        })}
-      </ListDndContext>
+      {visibleBlocks.map((f, index, arr) => {
+        let nextBlock = arr[index + 1];
+        let depth = f.listData?.depth || 1;
+        let nextDepth = nextBlock?.listData?.depth || 1;
+        let nextPosition: string | null;
+        if (depth === nextDepth) nextPosition = nextBlock?.position || null;
+        else nextPosition = null;
+        return (
+          <Block
+            pageType="doc"
+            {...f}
+            key={f.entityID}
+            entityID={f.entityID}
+            previousBlock={arr[index - 1] || null}
+            nextBlock={arr[index + 1] || null}
+            nextPosition={nextPosition}
+            headingFoldable={foldableParentSet.has(f.entityID) && !f.listData}
+            displayDepth={
+              zoomDepth && f.listData
+                ? f.listData.depth - zoomDepth + 1
+                : undefined
+            }
+          />
+        );
+      })}
       <NewBlockButton
         lastBlock={lastRootBlock || null}
         entityID={zoomedBlock ?? props.entityID}

--- a/components/Blocks/index.tsx
+++ b/components/Blocks/index.tsx
@@ -18,6 +18,7 @@ import { Block } from "./Block";
 import { useEffect, useMemo, useState } from "react";
 import { addShortcut } from "src/shortcuts";
 import { useHandleDrop } from "./useHandleDrop";
+import { ListDndContext } from "./ListDnd";
 import { useFootnoteContext } from "components/Footnotes/FootnoteContext";
 
 export function Blocks(props: { entityID: string }) {
@@ -64,9 +65,12 @@ export function Blocks(props: { entityID: string }) {
     (f) => !f.listData || f.listData.depth === 1,
   );
 
-  let lastVisibleBlock = blocks.findLast(
-    (f) => !isBlockHidden(f, foldedBlocks),
+  let visibleBlocks = useMemo(
+    () => blocks.filter((f) => !isBlockHidden(f, foldedBlocks)),
+    [blocks, foldedBlocks],
   );
+
+  let lastVisibleBlock = visibleBlocks[visibleBlocks.length - 1];
 
   let { footnotes } = useFootnoteContext();
 
@@ -86,9 +90,8 @@ export function Blocks(props: { entityID: string }) {
       // collapse out through the container's top edge.
       className={`blocks w-full flow-root outline-hidden ${areFootnotes ? "h-fit" : "min-h-full"}`}
     >
-      {blocks
-        .filter((f) => !isBlockHidden(f, foldedBlocks))
-        .map((f, index, arr) => {
+      <ListDndContext pageID={props.entityID} blocks={visibleBlocks}>
+        {visibleBlocks.map((f, index, arr) => {
           let nextBlock = arr[index + 1];
           let depth = f.listData?.depth || 1;
           let nextDepth = nextBlock?.listData?.depth || 1;
@@ -109,6 +112,7 @@ export function Blocks(props: { entityID: string }) {
             />
           );
         })}
+      </ListDndContext>
       <NewBlockButton
         lastBlock={lastRootBlock || null}
         entityID={props.entityID}

--- a/components/Blocks/index.tsx
+++ b/components/Blocks/index.tsx
@@ -18,7 +18,7 @@ import { Block } from "./Block";
 import { useEffect, useMemo, useState } from "react";
 import { addShortcut } from "src/shortcuts";
 import { useHandleDrop } from "./useHandleDrop";
-import { registerListDndPage, unregisterListDndPage } from "./ListDndState";
+import { listDndPages } from "./ListDndState";
 import { useFootnoteContext } from "components/Footnotes/FootnoteContext";
 
 export function Blocks(props: { entityID: string }) {
@@ -76,12 +76,12 @@ export function Blocks(props: { entityID: string }) {
   // Make this page a drop target for list items dragged from any open page
   // (the DndContext lives in ListDndProvider, above all pages).
   useEffect(() => {
-    registerListDndPage({
+    listDndPages.set(props.entityID, {
       pageID: props.entityID,
       blocks: visibleBlocks,
       zoomDepth,
     });
-    return () => unregisterListDndPage(props.entityID);
+    return () => void listDndPages.delete(props.entityID);
   }, [props.entityID, visibleBlocks, zoomDepth]);
 
   let { footnotes } = useFootnoteContext();

--- a/components/Blocks/useBlockKeyboardHandlers.ts
+++ b/components/Blocks/useBlockKeyboardHandlers.ts
@@ -18,7 +18,7 @@ import { entities } from "drizzle/schema";
 import { scanIndex } from "src/replicache/utils";
 
 export function useBlockKeyboardHandlers(
-  props: BlockProps,
+  props: BlockProps & { preview?: boolean },
   areYouSure: boolean,
   setAreYouSure: (value: boolean) => void,
 ) {
@@ -36,7 +36,9 @@ export function useBlockKeyboardHandlers(
   latest.current = { props, entity_set, areYouSure, setAreYouSure };
 
   useEffect(() => {
-    if (!isSelected || !rep) return;
+    // A preview copy (e.g. the list drag overlay) of a selected block must not
+    // attach a second listener for the same entity.
+    if (props.preview || !isSelected || !rep) return;
     let listener = async (e: KeyboardEvent) => {
       let { props, entity_set, areYouSure, setAreYouSure } = latest.current;
       // keymapping for textBlocks is handled in TextBlock/keymap

--- a/components/Pages/index.tsx
+++ b/components/Pages/index.tsx
@@ -59,7 +59,9 @@ export function Pages(props: { rootPage: string; flow?: boolean }) {
               <IframePageView
                 url={page.url}
                 onOpen={(url) => {
-                  useUIState.getState().openPage(page, { type: "iframe", url });
+                  useUIState
+                    .getState()
+                    .openPage(page, { type: "iframe", url });
                   requestAnimationFrame(() => {
                     requestAnimationFrame(() => {
                       scrollIntoViewIfNeeded(
@@ -74,7 +76,9 @@ export function Pages(props: { rootPage: string; flow?: boolean }) {
                 pageOptions={
                   <div className="pageOptions w-fit z-10 absolute sm:-right-[19px] right-3 sm:top-3 top-0 flex sm:flex-col flex-row-reverse gap-1 items-start">
                     <PageOptionButton
-                      onClick={() => useUIState.getState().closePage(page)}
+                      onClick={() =>
+                        useUIState.getState().closePage(page)
+                      }
                     >
                       <CloseTiny />
                     </PageOptionButton>

--- a/components/Pages/index.tsx
+++ b/components/Pages/index.tsx
@@ -10,6 +10,7 @@ import { useCardBorderHidden } from "./useCardBorderHidden";
 import { BookendSpacer, SandwichSpacer } from "components/LeafletLayout";
 import { LeafletSidebar } from "app/(app)/(editor)/[leaflet_id]/Sidebar";
 import { Page } from "./Page";
+import { ListDndProvider } from "components/Blocks/ListDnd";
 import { IframePageView } from "./IframePageView";
 import { PageOptionButton } from "./PageOptions";
 import { CloseTiny } from "components/Icons/CloseTiny";
@@ -27,7 +28,9 @@ export function Pages(props: { rootPage: string; flow?: boolean }) {
     !!cardBorderHidden && pages.length === 0 && !firstPageIsCanvas;
 
   return (
-    <>
+    // One drag context above every open page, so list items can be dragged
+    // between them (e.g. into an open subpage).
+    <ListDndProvider>
       <LeafletSidebar />
       {!fullPageScroll && !props.flow && (
         <BookendSpacer
@@ -56,9 +59,7 @@ export function Pages(props: { rootPage: string; flow?: boolean }) {
               <IframePageView
                 url={page.url}
                 onOpen={(url) => {
-                  useUIState
-                    .getState()
-                    .openPage(page, { type: "iframe", url });
+                  useUIState.getState().openPage(page, { type: "iframe", url });
                   requestAnimationFrame(() => {
                     requestAnimationFrame(() => {
                       scrollIntoViewIfNeeded(
@@ -73,9 +74,7 @@ export function Pages(props: { rootPage: string; flow?: boolean }) {
                 pageOptions={
                   <div className="pageOptions w-fit z-10 absolute sm:-right-[19px] right-3 sm:top-3 top-0 flex sm:flex-col flex-row-reverse gap-1 items-start">
                     <PageOptionButton
-                      onClick={() =>
-                        useUIState.getState().closePage(page)
-                      }
+                      onClick={() => useUIState.getState().closePage(page)}
                     >
                       <CloseTiny />
                     </PageOptionButton>
@@ -103,7 +102,7 @@ export function Pages(props: { rootPage: string; flow?: boolean }) {
           }}
         />
       )}
-    </>
+    </ListDndProvider>
   );
 }
 

--- a/src/replicache/mutations.ts
+++ b/src/replicache/mutations.ts
@@ -158,6 +158,7 @@ const moveBlock: Mutation<{
   position:
     | { type: "first" }
     | { type: "end" }
+    | { type: "before"; entity: string }
     | { type: "after"; entity: string };
 }> = async (args, ctx) => {
   let children = (
@@ -187,6 +188,14 @@ const moveBlock: Mutation<{
       newPosition = generateKeyBetween(
         newSiblings[newSiblings.length - 1]?.data.position || null,
         null,
+      );
+      break;
+    }
+    case "before": {
+      let index = newSiblings.findIndex((f) => f.data.value == pos.entity);
+      newPosition = generateKeyBetween(
+        (index > 0 && newSiblings[index - 1].data.position) || null,
+        newSiblings[index]?.data.position || null,
       );
       break;
     }

--- a/src/replicache/mutations.ts
+++ b/src/replicache/mutations.ts
@@ -367,6 +367,77 @@ const outdentBlock: Mutation<{
   });
 };
 
+// Drop a block one level above a list run, splitting that list: the children
+// of adoptParent from adoptFrom onward are appended under the block (after its
+// existing children, keeping their rendered depth), and the block itself lands
+// in newParent directly after `after` (adoptFrom's old parent). The outdentBlock
+// shape generalized to a block arriving from anywhere in the document.
+const moveBlockAdoptingSiblings: Mutation<{
+  block: string;
+  oldParent: string;
+  newParent: string;
+  after: string;
+  adoptParent: string;
+  adoptFrom: string;
+}> = async (args, ctx) => {
+  let oldSiblings = (
+    await ctx.scanIndex.eav(args.oldParent, "card/block")
+  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
+  let newSiblings = (
+    await ctx.scanIndex.eav(args.newParent, "card/block")
+  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
+  let adoptSiblings = (
+    await ctx.scanIndex.eav(args.adoptParent, "card/block")
+  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
+
+  let blockFact = oldSiblings.find((f) => f.data.value === args.block);
+  let afterIndex = newSiblings.findIndex((f) => f.data.value === args.after);
+  let adoptIndex = adoptSiblings.findIndex(
+    (f) => f.data.value === args.adoptFrom,
+  );
+  // Bail before any writes: a missing anchor must be a clean no-op, not a
+  // half-applied split that orphans the adopted run.
+  if (!blockFact || afterIndex === -1 || adoptIndex === -1) return;
+
+  let run = adoptSiblings
+    .slice(adoptIndex)
+    .filter((f) => f.data.value !== args.block);
+  let blockChildren = (
+    await ctx.scanIndex.eav(args.block, "card/block")
+  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
+  let lastPosition =
+    blockChildren[blockChildren.length - 1]?.data.position || null;
+  for (let sib of run) {
+    lastPosition = generateKeyBetween(lastPosition, null);
+    // Reparent in place (reusing the fact id) so undo/redo never passes
+    // through a state where a run member is gone.
+    await ctx.assertFact({
+      entity: args.block,
+      id: sib.id,
+      attribute: "card/block",
+      data: {
+        type: "ordered-reference",
+        position: lastPosition,
+        value: sib.data.value,
+      },
+    });
+  }
+
+  await ctx.assertFact({
+    id: blockFact.id,
+    entity: args.newParent,
+    attribute: "card/block",
+    data: {
+      type: "ordered-reference",
+      position: generateKeyBetween(
+        newSiblings[afterIndex]?.data.position || null,
+        newSiblings[afterIndex + 1]?.data.position || null,
+      ),
+      value: args.block,
+    },
+  });
+};
+
 const addPageLinkBlock: Mutation<{
   type: "canvas" | "doc";
   permission_set: string;
@@ -1280,6 +1351,7 @@ export const mutations = {
   addPublicationNavLink,
   removePublicationNavEntry,
   moveBlock,
+  moveBlockAdoptingSiblings,
   moveBlocks,
   assertFact,
   retractFact,

--- a/src/replicache/mutations.ts
+++ b/src/replicache/mutations.ts
@@ -370,77 +370,6 @@ const outdentBlock: Mutation<{
   });
 };
 
-// Drop a block one level above a list run, splitting that list: the children
-// of adoptParent from adoptFrom onward are appended under the block (after its
-// existing children, keeping their rendered depth), and the block itself lands
-// in newParent directly after `after` (adoptFrom's old parent). The outdentBlock
-// shape generalized to a block arriving from anywhere in the document.
-const moveBlockAdoptingSiblings: Mutation<{
-  block: string;
-  oldParent: string;
-  newParent: string;
-  after: string;
-  adoptParent: string;
-  adoptFrom: string;
-}> = async (args, ctx) => {
-  let oldSiblings = (
-    await ctx.scanIndex.eav(args.oldParent, "card/block")
-  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
-  let newSiblings = (
-    await ctx.scanIndex.eav(args.newParent, "card/block")
-  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
-  let adoptSiblings = (
-    await ctx.scanIndex.eav(args.adoptParent, "card/block")
-  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
-
-  let blockFact = oldSiblings.find((f) => f.data.value === args.block);
-  let afterIndex = newSiblings.findIndex((f) => f.data.value === args.after);
-  let adoptIndex = adoptSiblings.findIndex(
-    (f) => f.data.value === args.adoptFrom,
-  );
-  // Bail before any writes: a missing anchor must be a clean no-op, not a
-  // half-applied split that orphans the adopted run.
-  if (!blockFact || afterIndex === -1 || adoptIndex === -1) return;
-
-  let run = adoptSiblings
-    .slice(adoptIndex)
-    .filter((f) => f.data.value !== args.block);
-  let blockChildren = (
-    await ctx.scanIndex.eav(args.block, "card/block")
-  ).toSorted((a, b) => (a.data.position > b.data.position ? 1 : -1));
-  let lastPosition =
-    blockChildren[blockChildren.length - 1]?.data.position || null;
-  for (let sib of run) {
-    lastPosition = generateKeyBetween(lastPosition, null);
-    // Reparent in place (reusing the fact id) so undo/redo never passes
-    // through a state where a run member is gone.
-    await ctx.assertFact({
-      entity: args.block,
-      id: sib.id,
-      attribute: "card/block",
-      data: {
-        type: "ordered-reference",
-        position: lastPosition,
-        value: sib.data.value,
-      },
-    });
-  }
-
-  await ctx.assertFact({
-    id: blockFact.id,
-    entity: args.newParent,
-    attribute: "card/block",
-    data: {
-      type: "ordered-reference",
-      position: generateKeyBetween(
-        newSiblings[afterIndex]?.data.position || null,
-        newSiblings[afterIndex + 1]?.data.position || null,
-      ),
-      value: args.block,
-    },
-  });
-};
-
 const addPageLinkBlock: Mutation<{
   type: "canvas" | "doc";
   permission_set: string;
@@ -1354,7 +1283,6 @@ export const mutations = {
   addPublicationNavLink,
   removePublicationNavEntry,
   moveBlock,
-  moveBlockAdoptingSiblings,
   moveBlocks,
   assertFact,
   retractFact,


### PR DESCRIPTION
## Description

Implements drag-and-drop reordering for list items across pages using dnd-kit. Users can now long-press (250ms) or drag (8px movement) a list marker to reorder blocks within and across pages, with visual feedback via a drop indicator line.

### Key Changes

- **ListDnd.tsx** (new): Core drag-and-drop provider that:
  - Manages drag state and collision detection across all open pages
  - Computes drop targets with intelligent depth projection based on horizontal drag distance
  - Handles list splits (adopting child runs when dropping above them)
  - Prevents drops into descendant pages (avoiding circular references)
  - Unfolds collapsed blocks when necessary to prevent drops into hidden content

- **ListDndState.ts** (new): Shared state and context:
  - `useListDragState`: Zustand store for active drag ID and drop target (subscribed with primitive selectors to minimize re-renders)
  - `ListDragHandleContext`: Passes drag handle attributes from Block down to ListMarker
  - `listDndPages`: Map of visible block lists per page for cross-page drop resolution

- **Block.tsx**: 
  - Wraps draggable/droppable registration in `BlockListDnd` component (isolated to prevent re-renders during drag)
  - Dims dragged blocks and their subtree (opacity-30)
  - Renders drop indicator line via `ListDropIndicator`
  - Passes drag handle to ListMarker via context

- **ListMarker**: 
  - Registers as drag activator with long-press/movement constraints
  - Prevents fold toggle on click immediately after drop (250ms window)
  - Adds `touch-none select-none` when draggable

- **mutations.ts**: Added `"before"` position type to `moveBlock` for precise drop positioning

- **Blocks/index.tsx & Pages/index.tsx**: Register visible block lists with `listDndPages` for cross-page drops

- **PublicationDraftEditor.tsx**: Wraps content in `ListDndProvider`

### Behavior

- **Drag activation**: 250ms hold or 8px pointer movement (whichever comes first)
- **Depth projection**: Horizontal drag distance projects preferred indent level, clamped to valid range
- **List splits**: Dropping above a run adopts it as children, keeping rendered depth
- **Cross-page drops**: Blocked for pages inside the dragged subtree (prevents circular references)
- **Auto-unfold**: Unfolds collapsed blocks when drops would land in hidden content
- **Undo**: Multi-mutation drops (list splits) grouped into single undo step

## Testing

- [x] Looks good on mobile and desktop
- [x] Undo/redo works correctly (single step for list splits via `withUndoGroup`)
- [x] Keyboard interactions unaffected (drag activates on pointer, not keyboard)
- [x] No build errors
- [x] Drop indicator renders at correct depth and edge
- [x] Dragged blocks dim while preview shows in overlay
- [x] Cross-page drops work and prevent circular references
- [x] List splits adopt child runs correctly
- [x] Fold toggle doesn't fire on post-drop click

https://claude.ai/code/session_01UHP5r5eFu8TYupE9nUaHp2